### PR TITLE
✨ レシピの削除API作成

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,7 @@
     "clsx",
     "gitmoji",
     "ianvs",
+    "kumabiko",
     "lucide",
     "nextjs",
     "pnpx",
@@ -13,6 +14,7 @@
     "shadcn",
     "SUPABASE",
     "tailwindcss",
+    "tsuboi",
     "workdir"
   ],
   "[prisma]": {

--- a/src/actions/deleteRecipe.ts
+++ b/src/actions/deleteRecipe.ts
@@ -1,0 +1,31 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { prisma } from "@/src/lib/prisma";
+
+import getAuthenticatedUser from "./getAuthenticatedUser";
+
+export const deleteRecipe = async (formData: FormData) => {
+  const id = Number(formData.get("recipeId"));
+
+  const user = await getAuthenticatedUser();
+
+  if (user?.role !== "ADMIN") {
+    throw new Error("権限がありません");
+  }
+
+  // 論理削除
+  await prisma.recipe.update({
+    data: {
+      deletedAt: new Date(),
+      // TODO: 関連するデータも論理削除する
+    },
+    where: {
+      id,
+    },
+  });
+
+  // TODO: 適切なパスを指定する
+  revalidatePath("/mock");
+};

--- a/src/actions/getChefById.ts
+++ b/src/actions/getChefById.ts
@@ -8,7 +8,7 @@ const getChefById = async (id: string) => {
     include: {
       Recipe: true,
       followers: true,
-      ChefLink: true,
+      UserLink: true,
     },
   });
 

--- a/src/actions/getRecipes.ts
+++ b/src/actions/getRecipes.ts
@@ -1,13 +1,24 @@
 import { prisma } from "../lib/prisma";
 
-const getRecipes = async () => {
+type GetRecipesParams = {
+  page?: number;
+  limit?: number;
+};
+
+const getRecipes = async ({ page = 1, limit = 10 }: GetRecipesParams = {}) => {
   const recipe = await prisma.recipe.findMany({
     include: {
+      RecipeImage: true,
       likes: true,
     },
     orderBy: {
       createdAt: "desc",
     },
+    where: {
+      deletedAt: null,
+    },
+    skip: (page - 1) * limit,
+    take: limit,
   });
 
   return recipe;

--- a/src/actions/restoreRecipe.ts
+++ b/src/actions/restoreRecipe.ts
@@ -1,0 +1,28 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { prisma } from "../lib/prisma";
+import getAuthenticatedUser from "./getAuthenticatedUser";
+
+export const restoreRecipe = async (formData: FormData) => {
+  const id = Number(formData.get("recipeId"));
+
+  const user = await getAuthenticatedUser();
+
+  if (user?.role !== "ADMIN") {
+    throw new Error("権限がありません");
+  }
+
+  await prisma.recipe.update({
+    data: {
+      deletedAt: null,
+    },
+    where: {
+      id,
+    },
+  });
+
+  // TODO: 適切なパスを指定する
+  revalidatePath("/mock");
+};

--- a/src/app/mock/_components/delete-recipe-button.tsx
+++ b/src/app/mock/_components/delete-recipe-button.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { deleteRecipe } from "@/src/actions/deleteRecipe";
+import { restoreRecipe } from "@/src/actions/restoreRecipe";
+import { Button } from "@/src/components/ui/button";
+import { useToast } from "@/src/components/ui/use-toast";
+
+type Props = {
+  recipeId: number;
+};
+
+const DeleteRecipeButton = ({ recipeId }: Props) => {
+  const { toast, dismiss } = useToast();
+
+  return (
+    <>
+      <form className="self-end">
+        <input type="hidden" name="recipeId" value={recipeId} />
+        <Button
+          formAction={(formData: FormData) => {
+            deleteRecipe(formData)
+              .then(() => {
+                toast({
+                  variant: "default",
+                  title: "レシピを削除しました",
+                  action: (
+                    <form>
+                      <input type="hidden" name="recipeId" value={recipeId} />
+                      <Button
+                        formAction={(formData: FormData) => {
+                          restoreRecipe(formData)
+                            .then(() => {
+                              dismiss();
+                            })
+                            .catch((_) => {
+                              toast({
+                                variant: "destructive",
+                                title: "レシピの復元に失敗しました",
+                              });
+                            });
+                        }}
+                      >
+                        復元
+                      </Button>
+                    </form>
+                  ),
+                });
+              })
+              .catch(() => {
+                toast({
+                  variant: "destructive",
+                  title: "レシピの削除に失敗しました",
+                });
+              });
+          }}
+          className="w-fit bg-tomato11"
+        >
+          削除
+        </Button>
+      </form>
+    </>
+  );
+};
+
+export default DeleteRecipeButton;

--- a/src/app/mock/layout.tsx
+++ b/src/app/mock/layout.tsx
@@ -7,7 +7,7 @@ export const metadata = {
 
 export default function layout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="p-8">
+    <div className="p-8 mb-20">
       <Login />
       {children}
     </div>

--- a/src/app/mock/login.tsx
+++ b/src/app/mock/login.tsx
@@ -22,7 +22,7 @@ export default function Login() {
 
   const handleSignIn = async () => {
     await supabase.auth.signInWithPassword({
-      email: "test1@test.com",
+      email: "admin@test.com",
       password: "test123",
     });
 

--- a/src/app/mock/page.tsx
+++ b/src/app/mock/page.tsx
@@ -1,34 +1,26 @@
+import Link from "next/link";
+
 import getAuthenticatedUser from "@/src/actions/getAuthenticatedUser";
-import getRecipes from "@/src/actions/getRecipes";
-import RecipeCard from "@/src/components/recipe-card";
+import { Button } from "@/src/components/ui/button";
 import { Separator } from "@/src/components/ui/separator";
 
-import NewRecipe from "./_components/new-recipe";
-
 const page = async () => {
-  const myRecipes = await getRecipes();
-
   const user = await getAuthenticatedUser();
 
   return (
     <div className="pt-4">
       <h4 className="text-xl font-medium leading-none">🙌 Hello {user?.name} 🙌</h4>
-      <Separator className="my-2" />
-      <NewRecipe />
-      <Separator className="my-2" />
-      <h2 className="pt-2 text-2xl font-extrabold">レシピ一覧</h2>
-      <div className="grid grid-cols-2 gap-4 pt-4">
-        {myRecipes?.map((recipe) => (
-          <div key={recipe.id}>
-            <RecipeCard
-              favorites={recipe.likes.length}
-              comment={recipe.description}
-              recipeName={recipe.title}
-              imageUrl="https://images.unsplash.com/photo-1595295333158-4742f28fbd85?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=320&q=80"
-              recipeId={recipe.id}
-            />
-          </div>
-        ))}
+      <Separator className="my-4" />
+      <div className="flex gap-4">
+        <Link href="/mock/kumabiko" className="flex items-center gap-2">
+          <Button variant={"outline"}>kumabiko</Button>
+        </Link>
+        <Link href="/mock/kame" className="flex items-center gap-2">
+          <Button variant={"outline"}>kame</Button>
+        </Link>
+        <Link href="/mock/tsuboi" className="flex items-center gap-2">
+          <Button variant={"outline"}>tsuboi</Button>
+        </Link>
       </div>
     </div>
   );

--- a/src/app/mock/tsuboi/page.tsx
+++ b/src/app/mock/tsuboi/page.tsx
@@ -1,0 +1,37 @@
+import getAuthenticatedUser from "@/src/actions/getAuthenticatedUser";
+import getRecipes from "@/src/actions/getRecipes";
+import RecipeCard from "@/src/components/recipe-card";
+import { Separator } from "@/src/components/ui/separator";
+
+import DeleteRecipeButton from "../_components/delete-recipe-button";
+import NewRecipe from "../_components/new-recipe";
+
+const page = async () => {
+  const recipes = await getRecipes();
+
+  const user = await getAuthenticatedUser();
+
+  return (
+    <div className="pt-4">
+      <NewRecipe />
+      <Separator className="my-2" />
+      <h2 className="text-2xl font-extrabold pt-2">レシピ一覧</h2>
+      <div className="pt-4 grid grid-cols-2 gap-4 ">
+        {recipes?.map((recipe) => (
+          <div key={recipe.id} className="flex flex-col gap-2">
+            <RecipeCard
+              favorites={recipe.likes.length}
+              comment={recipe.description}
+              recipeName={recipe.title}
+              imageUrl="https://images.unsplash.com/photo-1595295333158-4742f28fbd85?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=320&q=80"
+              recipeId={recipe.id}
+            />
+            {user?.role === "ADMIN" && <DeleteRecipeButton recipeId={recipe.id} />}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default page;


### PR DESCRIPTION
## 関連する issue\*

<!--
次のいずれかを書いてください。
#issue番号（マージ時にまだ issue を close してはいけない場合）
（マージ時に issue を自動的に close させる場合）
-->

Closes #56 

## 作業内容\*

<!-- 変更箇所および内容 -->

### メイン実装

- レシピの論理削除APIの実装
    - shadcn/ui の toast を用いて復元できるように対応いたしました


https://github.com/qin-team-recipe/12-recipe-app/assets/63396451/c1ee0ee0-245a-4c2f-af8d-791d4fdd1539



### そのほか発生した実装

mockのルートパスに各々の開発パスの遷移ボタンを実装しました。（敬称略）

![スクリーンショット 2023-06-28 17 43 40](https://github.com/qin-team-recipe/12-recipe-app/assets/63396451/1a38611b-a91a-49b9-a2cc-22ba8d4d48fc)


## 残してある課題

## チェックリスト\*

### 実装者

- [x] ターゲットブランチが適切に設定されている。
- [x] 新規でのバグ・警告等が残っていない。
- [x] 本 PR に関係のない差分を含んでいない。
- [ ] PR の Assignee の設定。

## その他

admin権限を持つユーザーでないとレシピの削除ボタン表示されないので、admin権限を持つユーザーでサインインをしてもらって動作確認していただくようお願いいたします。

<!-- UIの変更などがあれば -->
