### PR TITLE
下書きレシピの画面 & 機能実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "tailwindcss": "3.3.2",
     "tailwindcss-animate": "^1.0.6",
     "typescript": "5.1.6",
+    "use-deep-compare-effect": "^1.8.1",
     "uuid": "^9.0.0",
     "zact": "^0.0.2",
     "zod": "^3.21.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 dependencies:
   '@hookform/resolvers':
     specifier: ^3.1.1
@@ -134,6 +130,9 @@ dependencies:
   typescript:
     specifier: 5.1.6
     version: 5.1.6
+  use-deep-compare-effect:
+    specifier: ^1.8.1
+    version: 1.8.1(react@18.2.0)
   uuid:
     specifier: ^9.0.0
     version: 9.0.0
@@ -6058,6 +6057,17 @@ packages:
       tslib: 2.6.0
     dev: false
 
+  /use-deep-compare-effect@1.8.1(react@18.2.0):
+    resolution: {integrity: sha512-kbeNVZ9Zkc0RFGpfMN3MNfaKNvcLNyxOAAd9O4CBZ+kCBXXscn9s/4I+8ytUER4RDpEYs5+O6Rs4PqiZ+rHr5Q==}
+    engines: {node: '>=10', npm: '>=6'}
+    peerDependencies:
+      react: '>=16.13'
+    dependencies:
+      '@babel/runtime': 7.22.6
+      dequal: 2.0.3
+      react: 18.2.0
+    dev: false
+
   /use-sidecar@1.1.2(@types/react@18.2.14)(react@18.2.0):
     resolution: {integrity: sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==}
     engines: {node: '>=10'}
@@ -6197,3 +6207,7 @@ packages:
   /zod@3.21.4:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
     dev: false
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false

--- a/src/actions/createDraftRecipe.ts
+++ b/src/actions/createDraftRecipe.ts
@@ -1,0 +1,81 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { prisma } from "@/src/lib/prisma";
+import { zact } from "zact/server";
+
+import { createDraftRecipeFormSchema } from "../components/create-recipe-form/schema";
+
+type CreateDraftRecipeResult = {
+  isSuccess: boolean;
+  error?: Error;
+};
+
+export const createDraftRecipe = zact(createDraftRecipeFormSchema)(
+  async ({
+    uid,
+    title,
+    bio,
+    ingredients,
+    urls,
+    servingCount,
+    instructions,
+    recipeImage,
+  }): Promise<CreateDraftRecipeResult> => {
+    try {
+      await prisma.draftRecipe.create({
+        data: {
+          title: title ?? "",
+          description: bio,
+          userId: uid,
+          servingCount: servingCount,
+
+          DraftRecipeImage:
+            recipeImage && recipeImage.length > 0
+              ? {
+                  create: {
+                    recipeImage: recipeImage ?? "",
+                  },
+                }
+              : undefined,
+
+          DraftIngredient:
+            ingredients && ingredients.filter((ingredient) => ingredient?.name).length > 0
+              ? {
+                  create: ingredients.map((ingredient) => ({
+                    title: ingredient?.name ?? "",
+                  })),
+                }
+              : undefined,
+
+          DraftInstruction:
+            instructions && instructions.filter((instruction) => instruction?.value).length > 0
+              ? {
+                  create: instructions.map((instruction, index) => ({
+                    stepOrder: index + 1,
+                    stepDescription: instruction?.value ?? "",
+                  })),
+                }
+              : undefined,
+
+          DraftRecipeLink:
+            urls && urls.filter((url) => url?.value).length > 0
+              ? {
+                  create: urls.map((url) => ({
+                    linkUrl: url?.value ?? "",
+                  })),
+                }
+              : undefined,
+        },
+      });
+
+      revalidatePath("/my-recipe/drafts");
+
+      return { isSuccess: true };
+    } catch (error) {
+      console.log(error);
+      return { isSuccess: false, error: error as Error };
+    }
+  }
+);

--- a/src/actions/deleteDraftRecipe.ts
+++ b/src/actions/deleteDraftRecipe.ts
@@ -1,0 +1,62 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { cookies } from "next/headers";
+
+import { prisma } from "@/src/lib/prisma";
+import { createServerActionClient } from "@supabase/auth-helpers-nextjs";
+
+import { Database } from "../types/SupabaseTypes";
+
+type DeleteDraftRecipeResult = {
+  isSuccess: boolean;
+  error?: Error;
+};
+
+export const deleteDraftRecipe = async (id: string): Promise<DeleteDraftRecipeResult> => {
+  const {
+    data: { session },
+  } = await createServerActionClient<Database>({ cookies }).auth.getSession();
+
+  if (!session) {
+    throw new Error("認証に失敗しました");
+  }
+
+  try {
+    // 物理削除
+    await prisma.$transaction([
+      prisma.draftRecipeImage.deleteMany({
+        where: {
+          draftRecipeId: id,
+        },
+      }),
+      prisma.draftRecipeLink.deleteMany({
+        where: {
+          draftRecipeId: id,
+        },
+      }),
+      prisma.draftInstruction.deleteMany({
+        where: {
+          draftRecipeId: id,
+        },
+      }),
+      prisma.draftIngredient.deleteMany({
+        where: {
+          draftRecipeId: id,
+        },
+      }),
+      prisma.draftRecipe.delete({
+        where: {
+          id,
+        },
+      }),
+    ]);
+
+    revalidatePath("/my-recipe/drafts");
+
+    return { isSuccess: true };
+  } catch (error) {
+    console.log(error);
+    return { isSuccess: false, error: error as Error };
+  }
+};

--- a/src/actions/followActions.ts
+++ b/src/actions/followActions.ts
@@ -20,7 +20,6 @@ export const followChef = async (followedId: string) => {
     throw new Error("認証に失敗しました🥲");
   }
 
-
   // 自身をフォローするのを防ぐ
   if (session.user.id === followedId) throw new Error("自分自身をフォロー・アンフォローすることはできません😡");
 
@@ -46,7 +45,6 @@ export const unFollowChef = async (followedId: string) => {
   if (!session) {
     throw new Error("認証に失敗しました🥲");
   }
-
 
   // 自身をフォローするのを防ぐ
   if (session.user.id === followedId) throw new Error("自分自身をフォロー・アンフォローすることはできません😡");

--- a/src/actions/getDraftRecipe.ts
+++ b/src/actions/getDraftRecipe.ts
@@ -1,0 +1,17 @@
+import { prisma } from "../lib/prisma";
+
+export const getDraftRecipe = async (id: string) => {
+  const draftRecipe = await prisma.draftRecipe.findUnique({
+    where: {
+      id,
+    },
+    include: {
+      DraftIngredient: true,
+      DraftInstruction: true,
+      DraftRecipeImage: true,
+      DraftRecipeLink: true,
+    },
+  });
+
+  return draftRecipe;
+};

--- a/src/actions/getDraftRecipes.ts
+++ b/src/actions/getDraftRecipes.ts
@@ -1,0 +1,34 @@
+import { cookies } from "next/headers";
+
+import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
+
+import { prisma } from "../lib/prisma";
+import { Database } from "../types/SupabaseTypes";
+
+export const getDraftRecipes = async () => {
+  const supabaseServerClient = createServerComponentClient<Database>({ cookies });
+
+  const {
+    data: { session },
+  } = await supabaseServerClient.auth.getSession();
+
+  if (!session) {
+    throw new Error("認証に失敗しました🥲");
+  }
+
+  const draftRecipes = await prisma.draftRecipe.findMany({
+    where: {
+      userId: session.user.id,
+    },
+    select: {
+      id: true,
+      title: true,
+      createdAt: true,
+    },
+    orderBy: {
+      createdAt: "desc",
+    },
+  });
+
+  return draftRecipes;
+};

--- a/src/app/mock/tsuboi/[id]/_components/recipe-hero.tsx
+++ b/src/app/mock/tsuboi/[id]/_components/recipe-hero.tsx
@@ -1,7 +1,6 @@
 import Link from "next/link";
 
 import { getRecipeById } from "@/src/actions/getRecipeById";
-import DetailHeaderImage from "@/src/components/detail-header-image";
 import LinkToIconRenderer from "@/src/components/link-to-icon-renderer";
 import NumberUnit from "@/src/components/number-unit";
 import ProfileLink from "@/src/components/profile-link";

--- a/src/app/my-recipe/[id]/ingredients/page.tsx
+++ b/src/app/my-recipe/[id]/ingredients/page.tsx
@@ -18,17 +18,17 @@ const page = async ({ params }: { params: { id: string } }) => {
           <span>まとめてお買い物リストに追加</span>
         </button>
       </div>
-      {ingredients.map(({ title, id }) => (
-        <ul key={id}>
-          <li className="flex justify-between border-b px-4 py-2">
+      <ul>
+        {ingredients.map(({ title, id }) => (
+          <li key={id} className="flex justify-between border-b px-4 py-2">
             <p className="">{title}</p>
             <button className=" pl-[20px] text-mauve11 hover:text-mauve12">
               {/* // TODO: お買い物リストに追加するロジックを実装する */}
               <ShoppingCart size={20} />
             </button>
           </li>
-        </ul>
-      ))}
+        ))}
+      </ul>
       <CopyToClipboardButton
         recipeName={title}
         servingCount={servingCount}

--- a/src/app/my-recipe/create/page.tsx
+++ b/src/app/my-recipe/create/page.tsx
@@ -1,13 +1,15 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
 
+import { deleteDraftRecipe } from "@/src/actions/deleteDraftRecipe";
 import { getAuthenticatedUser } from "@/src/actions/getAuthenticatedUser";
+import { getDraftRecipe } from "@/src/actions/getDraftRecipe";
 import TopBar from "@/src/components/layout/top-bar";
 
 import { CreateRecipeForm, CreateRecipeFormValues } from "../../../components/create-recipe-form";
 import CloseButton from "./_components/close-button";
 
-const page = async () => {
+const page = async ({ searchParams }: { searchParams: { [key: string]: string | undefined } }) => {
   const user = await getAuthenticatedUser();
 
   if (!user) {
@@ -15,7 +17,7 @@ const page = async () => {
     redirect("/mock/unauthorized");
   }
 
-  const defaultValues: Partial<CreateRecipeFormValues> = {
+  let defaultValues: Partial<CreateRecipeFormValues> = {
     uid: user.id,
     title: "",
     bio: "",
@@ -25,13 +27,63 @@ const page = async () => {
     servingCount: 1,
   };
 
+  const draftId = searchParams["draftId"];
+
+  if (draftId !== undefined) {
+    const draftRecipe = await getDraftRecipe(draftId);
+
+    if (!draftRecipe) {
+      redirect("/my-page");
+    }
+
+    const {
+      userId,
+      title,
+      description,
+      servingCount,
+      DraftIngredient: draftIngredient,
+      DraftInstruction: draftInstruction,
+      DraftRecipeImage: draftRecipeImage,
+      DraftRecipeLink: draftRecipeLink,
+    } = draftRecipe;
+
+    defaultValues = {
+      uid: userId,
+      title: title || "",
+      bio: description || "",
+      ingredients:
+        draftIngredient.filter((ingredient) => ingredient?.title).length > 0
+          ? draftIngredient.map((ingredient) => {
+              return {
+                name: ingredient?.title || "",
+              };
+            })
+          : [{ name: "" }],
+      instructions:
+        draftInstruction && draftInstruction.length > 0
+          ? draftInstruction.map((instruction) => {
+              return { value: instruction?.stepDescription || "" };
+            })
+          : [{ value: "" }],
+      urls:
+        draftRecipeLink && draftRecipeLink.filter((url) => url?.linkUrl).length > 0
+          ? draftRecipeLink.map((url) => {
+              return { value: url?.linkUrl || "" };
+            })
+          : [{ value: "" }],
+      servingCount: servingCount || 1,
+    };
+
+    await deleteDraftRecipe(draftId);
+  }
+
   return (
     <>
       <TopBar
         leadingComponent={<CloseButton />}
         trailingComponent={
-          <Link href="/my-recipe/drafts">
-            <button className="text-xl font-bold text-mauve11">下書き一覧</button>
+          <Link href="/my-recipe/drafts" className="text-xl font-bold text-mauve11">
+            下書き一覧
           </Link>
         }
       />

--- a/src/app/my-recipe/drafts/_components/draft-recipe-tile.tsx
+++ b/src/app/my-recipe/drafts/_components/draft-recipe-tile.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useTransition } from "react";
+
+import { deleteDraftRecipe } from "@/src/actions/deleteDraftRecipe";
+import QueryParamsLink from "@/src/components/query-params-link";
+import { Command, CommandItem, CommandList } from "@/src/components/ui/command";
+import { Popover, PopoverContent, PopoverTrigger } from "@/src/components/ui/popover";
+import Spinner from "@/src/components/ui/spinner";
+import { useToast } from "@/src/components/ui/use-toast";
+import { MoreVertical, Pencil, Pointer, Trash } from "lucide-react";
+
+type Props = {
+  id: string;
+  title: string | null;
+  createdAt: Date | null;
+};
+
+const DraftRecipeTile = ({ id, title, createdAt }: Props) => {
+  const [isPending, startTransition] = useTransition();
+  const { toast } = useToast();
+
+  return (
+    <>
+      <div className="flex flex-col">
+        <p className="">{title ? title : "レシピ名未記載"}</p>
+        {createdAt && (
+          <p className="text-sm text-mauve10">
+            作成日時:{" "}
+            {new Date(createdAt).toLocaleDateString("ja-JP", {
+              year: "numeric",
+              month: "long",
+              day: "numeric",
+            })}
+          </p>
+        )}
+      </div>
+      <Popover>
+        <PopoverTrigger>
+          <MoreVertical size={20} />
+        </PopoverTrigger>
+        <PopoverContent align="end" className="p-2">
+          <Command className="w-full">
+            <CommandList>
+              <CommandItem>
+                <QueryParamsLink path="/my-recipe/create" name="draftId" value={id} className="flex">
+                  <Pointer className="mr-2 h-4 w-4" />
+                  <span>この下書きを使用する</span>
+                </QueryParamsLink>
+              </CommandItem>
+              <CommandItem className="text-mauve11">
+                <button
+                  className="flex"
+                  onClick={() => {
+                    startTransition(async () => {
+                      const { isSuccess } = await deleteDraftRecipe(id);
+
+                      if (isSuccess) {
+                        toast({
+                          variant: "default",
+                          title: "下書きレシピを削除しました",
+                          duration: 1500,
+                        });
+                      } else {
+                        toast({
+                          variant: "destructive",
+                          title: "下書きレシピの削除に失敗しました",
+                          duration: 1500,
+                        });
+                      }
+                    });
+                  }}
+                >
+                  <Trash className="mr-2 h-4 w-4" />
+                  <span>{isPending ? <Spinner /> : "下書きを削除する"}</span>
+                </button>
+              </CommandItem>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+    </>
+  );
+};
+
+export default DraftRecipeTile;

--- a/src/app/my-recipe/drafts/page.tsx
+++ b/src/app/my-recipe/drafts/page.tsx
@@ -1,0 +1,40 @@
+import Link from "next/link";
+
+import { getDraftRecipes } from "@/src/actions/getDraftRecipes";
+import TopBar from "@/src/components/layout/top-bar";
+import NoDataDisplay from "@/src/components/no-data-display";
+import { ArrowLeft } from "lucide-react";
+
+import DraftRecipeTile from "./_components/draft-recipe-tile";
+
+const page = async () => {
+  const draftRecipes = await getDraftRecipes();
+
+  return (
+    <>
+      <TopBar
+        leadingComponent={
+          <div className="flex items-center gap-3">
+            <Link href={"/my-recipe/create"}>
+              <ArrowLeft size={20} />
+            </Link>
+            <h1 className="font-bold text-mauve11 md:text-xl">下書き</h1>
+          </div>
+        }
+      />
+      {draftRecipes.length > 0 ? (
+        <ul>
+          {draftRecipes.map(({ title, id, createdAt }) => (
+            <li key={id} className="flex cursor-pointer justify-between border-b px-4 py-2">
+              <DraftRecipeTile {...{ title, id, createdAt }} />
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <NoDataDisplay text="下書きのレシピはありません。" />
+      )}
+    </>
+  );
+};
+
+export default page;

--- a/src/atoms/draftRecipeFormValuesAtom.ts
+++ b/src/atoms/draftRecipeFormValuesAtom.ts
@@ -1,0 +1,9 @@
+import { atom } from "jotai";
+
+import { CreateRecipeFormValues } from "../components/create-recipe-form";
+import { CreateDraftRecipeFormValues } from "../components/create-recipe-form/schema";
+
+export const recipeFormStateAtom = atom<{ isDraft: boolean; draftRecipeFormValues: CreateDraftRecipeFormValues }>({
+  isDraft: false,
+  draftRecipeFormValues: {} as CreateDraftRecipeFormValues,
+});

--- a/src/components/create-recipe-form/schema.ts
+++ b/src/components/create-recipe-form/schema.ts
@@ -2,6 +2,8 @@ import * as z from "zod";
 
 export type CreateRecipeFormValues = z.infer<typeof createRecipeFormSchema>;
 
+export type CreateDraftRecipeFormValues = z.infer<typeof createDraftRecipeFormSchema>;
+
 export const createRecipeFormSchema = z.object({
   uid: z.string(),
 
@@ -49,4 +51,42 @@ export const createRecipeFormSchema = z.object({
       })
       .optional()
   ),
+});
+
+export const createDraftRecipeFormSchema = z.object({
+  uid: z.string(),
+  title: z.string().optional(),
+  servingCount: z.number().int().optional(),
+  recipeImage: z.string().optional(),
+  ingredients: z
+    .array(
+      z.object({
+        name: z.string().optional(),
+      })
+    )
+    .optional(),
+  instructions: z
+    .array(
+      z.object({
+        value: z.string().optional(),
+      })
+    )
+    .optional(),
+  bio: z.string().optional(),
+  urls: z
+    .array(
+      z
+        .object({
+          value: z
+            .string()
+            .optional()
+            .refine((value) => {
+              if (!value) return true;
+              const parseResult = z.string().url().safeParse(value);
+              return parseResult.success;
+            }, "正しいURLを入力してください"),
+        })
+        .optional()
+    )
+    .optional(),
 });

--- a/src/components/query-params-link.tsx
+++ b/src/components/query-params-link.tsx
@@ -4,14 +4,17 @@ import { useCallback } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 
+import { cn } from "../lib/utils";
+
 type Props = {
   name: string;
   value: string;
   path: string;
   children: React.ReactNode;
+  className?: string;
 };
 
-const QueryParamsLink = ({ name, value, path, children }: Props) => {
+const QueryParamsLink = ({ name, value, path, children, className }: Props) => {
   const searchParams = useSearchParams()!;
 
   const createQueryString = useCallback(
@@ -24,7 +27,11 @@ const QueryParamsLink = ({ name, value, path, children }: Props) => {
     [searchParams]
   );
 
-  return <Link href={path + "?" + createQueryString(name, value)}>{children}</Link>;
+  return (
+    <Link className={cn(className)} href={path + "?" + createQueryString(name, value)}>
+      {children}
+    </Link>
+  );
 };
 
 export default QueryParamsLink;

--- a/src/components/toggle-button.tsx
+++ b/src/components/toggle-button.tsx
@@ -3,7 +3,6 @@
 import { cn } from "../lib/utils";
 import { Button } from "./ui/button";
 
-
 interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   isActive: boolean;
   activeLabel: string;

--- a/src/prisma/migrations/20230729065200_v14/migration.sql
+++ b/src/prisma/migrations/20230729065200_v14/migration.sql
@@ -1,0 +1,76 @@
+-- CreateTable
+CREATE TABLE "DraftRecipe" (
+    "id" TEXT NOT NULL,
+    "title" TEXT,
+    "description" TEXT,
+    "user_id" TEXT NOT NULL,
+    "serving_count" INTEGER,
+    "created_at" TIMESTAMPTZ(3) DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(3) DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "DraftRecipe_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "DraftRecipeImage" (
+    "id" TEXT NOT NULL,
+    "draft_recipe_id" TEXT NOT NULL,
+    "recipe_image" TEXT NOT NULL,
+    "created_at" TIMESTAMPTZ(3) DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(3) DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "DraftRecipeImage_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "DraftInstruction" (
+    "id" SERIAL NOT NULL,
+    "draft_recipe_id" TEXT NOT NULL,
+    "step_order" INTEGER NOT NULL,
+    "step_description" TEXT NOT NULL,
+    "created_at" TIMESTAMPTZ(3) DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(3) DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "DraftInstruction_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "DraftIngredient" (
+    "id" SERIAL NOT NULL,
+    "title" TEXT NOT NULL,
+    "draft_recipe_id" TEXT NOT NULL,
+    "is_custom" BOOLEAN NOT NULL DEFAULT false,
+    "created_at" TIMESTAMPTZ(3) DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(3) DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "DraftIngredient_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "DraftRecipeLink" (
+    "id" TEXT NOT NULL,
+    "draft_recipe_id" TEXT NOT NULL,
+    "link_url" TEXT NOT NULL,
+    "created_at" TIMESTAMPTZ(3) DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(3) DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "DraftRecipeLink_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DraftInstruction_draft_recipe_id_step_order_key" ON "DraftInstruction"("draft_recipe_id", "step_order");
+
+-- AddForeignKey
+ALTER TABLE "DraftRecipe" ADD CONSTRAINT "DraftRecipe_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DraftRecipeImage" ADD CONSTRAINT "DraftRecipeImage_draft_recipe_id_fkey" FOREIGN KEY ("draft_recipe_id") REFERENCES "DraftRecipe"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DraftInstruction" ADD CONSTRAINT "DraftInstruction_draft_recipe_id_fkey" FOREIGN KEY ("draft_recipe_id") REFERENCES "DraftRecipe"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DraftIngredient" ADD CONSTRAINT "DraftIngredient_draft_recipe_id_fkey" FOREIGN KEY ("draft_recipe_id") REFERENCES "DraftRecipe"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DraftRecipeLink" ADD CONSTRAINT "DraftRecipeLink_draft_recipe_id_fkey" FOREIGN KEY ("draft_recipe_id") REFERENCES "DraftRecipe"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -29,6 +29,7 @@ model User {
   Memo         Memo[]
   createdAt    DateTime?      @default(now()) @map("created_at") @db.Timestamptz(3)
   updatedAt    DateTime?      @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(3)
+  DraftRecipe  DraftRecipe[]
 }
 
 /// レシピ
@@ -49,10 +50,71 @@ model Recipe {
   updatedAt    DateTime?     @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(3)
 }
 
+/// レシピの下書き
+model DraftRecipe {
+  id               String             @id @default(cuid())
+  title            String?
+  description      String?            @db.Text
+  user             User               @relation(fields: [userId], references: [id])
+  userId           String             @map("user_id")
+  servingCount     Int?               @map("serving_count")
+  DraftRecipeImage DraftRecipeImage[]
+  DraftInstruction DraftInstruction[]
+  DraftIngredient  DraftIngredient[]
+  DraftRecipeLink  DraftRecipeLink[]
+  createdAt        DateTime?          @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt        DateTime?          @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(3)
+}
+
+/// ドラフトレシピの画像
+model DraftRecipeImage {
+  id            String       @id @default(uuid())
+  recipe        DraftRecipe? @relation(fields: [draftRecipeId], references: [id], onDelete: Cascade)
+  draftRecipeId String       @map("draft_recipe_id")
+  recipeImage   String       @map("recipe_image") @db.Text
+  createdAt     DateTime?    @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt     DateTime?    @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(3)
+}
+
+/// ドラフトレシピの作り方
+model DraftInstruction {
+  id              Int          @id @default(autoincrement())
+  recipe          DraftRecipe? @relation(fields: [draftRecipeId], references: [id], onDelete: Cascade)
+  draftRecipeId   String       @map("draft_recipe_id")
+  stepOrder       Int          @map("step_order")
+  stepDescription String       @map("step_description") @db.Text
+  createdAt       DateTime?    @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt       DateTime?    @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(3)
+
+  //* 同じレシピに同じ手順を複数回登録することを防ぐ
+  @@unique([draftRecipeId, stepOrder])
+}
+
+/// 材料
+model DraftIngredient {
+  id            Int          @id @default(autoincrement())
+  title         String       @db.Text
+  recipe        DraftRecipe? @relation(fields: [draftRecipeId], references: [id], onDelete: Cascade)
+  draftRecipeId String       @map("draft_recipe_id")
+  isCustom      Boolean      @default(false) @map("is_custom")
+  createdAt     DateTime?    @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt     DateTime?    @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(3)
+}
+
+/// レシピのリンク
+model DraftRecipeLink {
+  id            String       @id @default(uuid())
+  recipe        DraftRecipe? @relation(fields: [draftRecipeId], references: [id], onDelete: Cascade)
+  draftRecipeId String       @map("draft_recipe_id")
+  linkUrl       String       @map("link_url") @db.Text
+  createdAt     DateTime?    @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt     DateTime?    @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(3)
+}
+
 /// レシピの画像
 model RecipeImage {
   id          String    @id @default(uuid())
-  recipe      Recipe    @relation(fields: [recipeId], references: [id], onDelete: Cascade)
+  recipe      Recipe?   @relation(fields: [recipeId], references: [id], onDelete: Cascade)
   recipeId    String    @map("recipe_id")
   recipeImage String    @map("recipe_image") @db.Text
   createdAt   DateTime? @default(now()) @map("created_at") @db.Timestamptz(3)

--- a/src/types/SupabaseTypes.ts
+++ b/src/types/SupabaseTypes.ts
@@ -116,6 +116,173 @@ export interface Database {
           }
         ];
       };
+      DraftIngredient: {
+        Row: {
+          created_at: string | null;
+          draft_recipe_id: string;
+          id: number;
+          is_custom: boolean;
+          title: string;
+          updated_at: string | null;
+        };
+        Insert: {
+          created_at?: string | null;
+          draft_recipe_id: string;
+          id?: number;
+          is_custom?: boolean;
+          title: string;
+          updated_at?: string | null;
+        };
+        Update: {
+          created_at?: string | null;
+          draft_recipe_id?: string;
+          id?: number;
+          is_custom?: boolean;
+          title?: string;
+          updated_at?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "DraftIngredient_draft_recipe_id_fkey";
+            columns: ["draft_recipe_id"];
+            referencedRelation: "DraftRecipe";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
+      DraftInstruction: {
+        Row: {
+          created_at: string | null;
+          draft_recipe_id: string;
+          id: number;
+          step_description: string;
+          step_order: number;
+          updated_at: string | null;
+        };
+        Insert: {
+          created_at?: string | null;
+          draft_recipe_id: string;
+          id?: number;
+          step_description: string;
+          step_order: number;
+          updated_at?: string | null;
+        };
+        Update: {
+          created_at?: string | null;
+          draft_recipe_id?: string;
+          id?: number;
+          step_description?: string;
+          step_order?: number;
+          updated_at?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "DraftInstruction_draft_recipe_id_fkey";
+            columns: ["draft_recipe_id"];
+            referencedRelation: "DraftRecipe";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
+      DraftRecipe: {
+        Row: {
+          created_at: string | null;
+          description: string | null;
+          id: string;
+          serving_count: number | null;
+          title: string | null;
+          updated_at: string | null;
+          user_id: string;
+        };
+        Insert: {
+          created_at?: string | null;
+          description?: string | null;
+          id: string;
+          serving_count?: number | null;
+          title?: string | null;
+          updated_at?: string | null;
+          user_id: string;
+        };
+        Update: {
+          created_at?: string | null;
+          description?: string | null;
+          id?: string;
+          serving_count?: number | null;
+          title?: string | null;
+          updated_at?: string | null;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "DraftRecipe_user_id_fkey";
+            columns: ["user_id"];
+            referencedRelation: "User";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
+      DraftRecipeImage: {
+        Row: {
+          created_at: string | null;
+          draft_recipe_id: string;
+          id: string;
+          recipe_image: string;
+          updated_at: string | null;
+        };
+        Insert: {
+          created_at?: string | null;
+          draft_recipe_id: string;
+          id: string;
+          recipe_image: string;
+          updated_at?: string | null;
+        };
+        Update: {
+          created_at?: string | null;
+          draft_recipe_id?: string;
+          id?: string;
+          recipe_image?: string;
+          updated_at?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "DraftRecipeImage_draft_recipe_id_fkey";
+            columns: ["draft_recipe_id"];
+            referencedRelation: "DraftRecipe";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
+      DraftRecipeLink: {
+        Row: {
+          created_at: string | null;
+          draft_recipe_id: string;
+          id: string;
+          link_url: string;
+          updated_at: string | null;
+        };
+        Insert: {
+          created_at?: string | null;
+          draft_recipe_id: string;
+          id: string;
+          link_url: string;
+          updated_at?: string | null;
+        };
+        Update: {
+          created_at?: string | null;
+          draft_recipe_id?: string;
+          id?: string;
+          link_url?: string;
+          updated_at?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "DraftRecipeLink_draft_recipe_id_fkey";
+            columns: ["draft_recipe_id"];
+            referencedRelation: "DraftRecipe";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       Favorite: {
         Row: {
           created_at: string | null;


### PR DESCRIPTION
## 関連する issue\*

<!--
次のいずれかを書いてください。
#issue番号（マージ時にまだ issue を close してはいけない場合）
Closes #番号（マージ時に issue を自動的に close させる場合）
-->

Closes #104 

## 作業内容\*

<!-- 変更箇所および内容 -->

### メイン実装

下書き画面の実装

figmaのデザインでは下書きのタイルの3点アイコンを押下時に「編集する」となっていますが、個人的に下書きの編集？？と疑問に感じたので文言を「この下書きを使用する」に変更しています。
こちらはそもそも3点アイコンは必要か（下書きのタイルをタップすると下書きが使用される、また削除アイコンはタイルの右端に配置）と考えているので、本日の進捗説明会で議題にあげようと思います。

![スクリーンショット 2023-07-30 15 28 47](https://github.com/qin-team-recipe/12-recipe-app/assets/63396451/9b7a73e5-e649-49bb-a268-064cccb9f106)




下書きのスキーマ定義 & API実装

以前、BEのMTGで下書きについてはRecipeのスキーマに`isDraft`とフィールドを追加するという話になっていたと思いますが、以下の理由で別途下書きに関するスキーマを定義しました。

- MTGでも触れたかと思いますがRecipeのタイトル、作り方、材料は必須のフィールドで下書きレシピを作成する際にこれらのフィールドに（半ば無理やり）空文字を入れるのがやはり違和感かと
- レシピと下書きレシピは同じデータ構造かと考えたときに、レシピにはFavoriteやCartListテーブルが紐づくかと思いますが、下書きレシピにはそれらが不要
- 下書きをRecipeテーブルに含めてしまうと当たり前ですがその分レシピに関するデータが膨らむ。 例えば下書きの一覧取得時、全てのレシピにアクセスして`isDraft`がtrueのものに絞ると思いますが、プロダクトの仕様的にRecipeテーブルにデータが入ると思いますので無駄なデータアクセスとなってしまう。

https://github.com/qin-team-recipe/12-recipe-app/assets/63396451/0041f195-5f2e-4253-8aab-aaeb45a1819c





### そのほか発生した実装

## 残してある課題

## チェックリスト\*

### 実装者

- [x] ターゲットブランチが適切に設定されている。
- [x] 新規でのバグ・警告等が残っていない。
- [x] 本 PR に関係のない差分を含んでいない。
- [ ] PR の Assignee の設定。

## その他

<!-- UIの変更などがあれば -->
