### PR TITLE
🐛 レシピの取得系APIの修正 & マイレシピの公開非公開フラグの適応

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 dependencies:
   '@hookform/resolvers':
     specifier: ^3.1.1
@@ -6189,7 +6193,3 @@ packages:
   /zod@3.21.4:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
     dev: false
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false

--- a/src/actions/actionsForCartList.ts
+++ b/src/actions/actionsForCartList.ts
@@ -9,11 +9,10 @@ import { Database } from "@/src/types/SupabaseTypes";
 import { createServerActionClient } from "@supabase/auth-helpers-nextjs";
 
 export const addCartList = async (recipeId: string, ingredientId: number): Promise<ActionsResult> => {
-  const supabaseServerClient = createServerActionClient<Database>({ cookies });
-
+  const cookieStore = cookies();
   const {
     data: { session },
-  } = await supabaseServerClient.auth.getSession();
+  } = await createServerActionClient<Database>({ cookies: () => cookieStore }).auth.getSession();
 
   if (!session) redirect("/login");
 

--- a/src/actions/actionsForCartList.ts
+++ b/src/actions/actionsForCartList.ts
@@ -3,11 +3,10 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
+import { prisma } from "@/src/lib/prisma";
+import { ActionsResult } from "@/src/types/ActionsResult";
+import { Database } from "@/src/types/SupabaseTypes";
 import { createServerActionClient } from "@supabase/auth-helpers-nextjs";
-
-import { prisma } from "../lib/prisma";
-import { ActionsResult } from "../types/ActionsResult";
-import { Database } from "../types/SupabaseTypes";
 
 export const addCartList = async (recipeId: string, ingredientId: number): Promise<ActionsResult> => {
   const supabaseServerClient = createServerActionClient<Database>({ cookies });

--- a/src/actions/actionsForFavoriteRecipe.ts
+++ b/src/actions/actionsForFavoriteRecipe.ts
@@ -4,11 +4,10 @@ import { revalidatePath } from "next/cache";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
+import { prisma } from "@/src/lib/prisma";
+import { ActionsResult } from "@/src/types/ActionsResult";
+import { Database } from "@/src/types/SupabaseTypes";
 import { createServerActionClient } from "@supabase/auth-helpers-nextjs";
-
-import { prisma } from "../lib/prisma";
-import { ActionsResult } from "../types/ActionsResult";
-import { Database } from "../types/SupabaseTypes";
 
 export const favoriteRecipe = async (recipeId: string): Promise<ActionsResult> => {
   const {

--- a/src/actions/actionsForFavoriteRecipe.ts
+++ b/src/actions/actionsForFavoriteRecipe.ts
@@ -10,9 +10,10 @@ import { Database } from "@/src/types/SupabaseTypes";
 import { createServerActionClient } from "@supabase/auth-helpers-nextjs";
 
 export const favoriteRecipe = async (recipeId: string): Promise<ActionsResult> => {
+  const cookieStore = cookies();
   const {
     data: { session },
-  } = await createServerActionClient<Database>({ cookies }).auth.getSession();
+  } = await createServerActionClient<Database>({ cookies: () => cookieStore }).auth.getSession();
 
   if (!session) redirect("/login");
 

--- a/src/actions/actionsForFollow.ts
+++ b/src/actions/actionsForFollow.ts
@@ -11,11 +11,10 @@ import { createServerActionClient } from "@supabase/auth-helpers-nextjs";
 
 // シェフをフォローする
 export const followChef = async (followedId: string): Promise<ActionsResult> => {
-  const supabaseServerClient = createServerActionClient<Database>({ cookies });
-
+  const cookieStore = cookies();
   const {
     data: { session },
-  } = await supabaseServerClient.auth.getSession();
+  } = await createServerActionClient<Database>({ cookies: () => cookieStore }).auth.getSession();
 
   if (!session) redirect("/login");
 

--- a/src/actions/actionsForFollow.ts
+++ b/src/actions/actionsForFollow.ts
@@ -4,11 +4,10 @@ import { revalidatePath } from "next/cache";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
+import { prisma } from "@/src/lib/prisma";
+import { ActionsResult } from "@/src/types/ActionsResult";
+import { Database } from "@/src/types/SupabaseTypes";
 import { createServerActionClient } from "@supabase/auth-helpers-nextjs";
-
-import { prisma } from "../lib/prisma";
-import { ActionsResult } from "../types/ActionsResult";
-import { Database } from "../types/SupabaseTypes";
 
 // シェフをフォローする
 export const followChef = async (followedId: string): Promise<ActionsResult> => {

--- a/src/actions/deleteChefs.ts
+++ b/src/actions/deleteChefs.ts
@@ -3,8 +3,7 @@
 import { revalidatePath } from "next/cache";
 
 import { prisma } from "@/src/lib/prisma";
-
-import { ActionsResult } from "../types/ActionsResult";
+import { ActionsResult } from "@/src/types/ActionsResult";
 
 export const deleteChefs = async (chefIds: string[]): Promise<ActionsResult> => {
   try {

--- a/src/actions/deleteDraftRecipe.ts
+++ b/src/actions/deleteDraftRecipe.ts
@@ -2,6 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
 
 import { prisma } from "@/src/lib/prisma";
 import { Database } from "@/src/types/SupabaseTypes";
@@ -13,13 +14,12 @@ type DeleteDraftRecipeResult = {
 };
 
 export const deleteDraftRecipe = async (id: string): Promise<DeleteDraftRecipeResult> => {
+  const cookieStore = cookies();
   const {
     data: { session },
-  } = await createServerActionClient<Database>({ cookies }).auth.getSession();
+  } = await createServerActionClient<Database>({ cookies: () => cookieStore }).auth.getSession();
 
-  if (!session) {
-    throw new Error("認証に失敗しました");
-  }
+  if (!session) redirect("/login");
 
   try {
     // 物理削除

--- a/src/actions/deleteDraftRecipe.ts
+++ b/src/actions/deleteDraftRecipe.ts
@@ -4,9 +4,8 @@ import { revalidatePath } from "next/cache";
 import { cookies } from "next/headers";
 
 import { prisma } from "@/src/lib/prisma";
+import { Database } from "@/src/types/SupabaseTypes";
 import { createServerActionClient } from "@supabase/auth-helpers-nextjs";
-
-import { Database } from "../types/SupabaseTypes";
 
 type DeleteDraftRecipeResult = {
   isSuccess: boolean;

--- a/src/actions/deleteMemo.ts
+++ b/src/actions/deleteMemo.ts
@@ -2,8 +2,8 @@
 
 import { revalidatePath } from "next/cache";
 
-import { prisma } from "../lib/prisma";
-import { ActionsResult } from "../types/ActionsResult";
+import { prisma } from "@/src/lib/prisma";
+import { ActionsResult } from "@/src/types/ActionsResult";
 
 export const deleteMemo = async (id: number): Promise<ActionsResult> => {
   try {

--- a/src/actions/deleteRecipe.ts
+++ b/src/actions/deleteRecipe.ts
@@ -5,10 +5,9 @@ import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
 import { prisma } from "@/src/lib/prisma";
+import { ActionsResult } from "@/src/types/ActionsResult";
+import { Database } from "@/src/types/SupabaseTypes";
 import { createServerActionClient } from "@supabase/auth-helpers-nextjs";
-
-import { ActionsResult } from "../types/ActionsResult";
-import { Database } from "../types/SupabaseTypes";
 
 export const deleteRecipe = async (id: string): Promise<ActionsResult> => {
   const {

--- a/src/actions/deleteRecipe.ts
+++ b/src/actions/deleteRecipe.ts
@@ -10,9 +10,10 @@ import { Database } from "@/src/types/SupabaseTypes";
 import { createServerActionClient } from "@supabase/auth-helpers-nextjs";
 
 export const deleteRecipe = async (id: string): Promise<ActionsResult> => {
+  const cookieStore = cookies();
   const {
     data: { session },
-  } = await createServerActionClient<Database>({ cookies }).auth.getSession();
+  } = await createServerActionClient<Database>({ cookies: () => cookieStore }).auth.getSession();
 
   if (!session) redirect("/login");
 

--- a/src/actions/getAuthenticatedUser.ts
+++ b/src/actions/getAuthenticatedUser.ts
@@ -1,10 +1,9 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
+import { prisma } from "@/src/lib/prisma";
+import { Database } from "@/src/types/SupabaseTypes";
 import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
-
-import { prisma } from "../lib/prisma";
-import { Database } from "../types/SupabaseTypes";
 
 export const getAuthenticatedUser = async () => {
   const supabaseServerClient = createServerComponentClient<Database>({ cookies });

--- a/src/actions/getAuthenticatedUser.ts
+++ b/src/actions/getAuthenticatedUser.ts
@@ -6,11 +6,10 @@ import { Database } from "@/src/types/SupabaseTypes";
 import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
 
 export const getAuthenticatedUser = async () => {
-  const supabaseServerClient = createServerComponentClient<Database>({ cookies });
-
+  const cookieStore = cookies();
   const {
     data: { session },
-  } = await supabaseServerClient.auth.getSession();
+  } = await createServerComponentClient<Database>({ cookies: () => cookieStore }).auth.getSession();
 
   if (!session) redirect("/login");
 

--- a/src/actions/getCartList.ts
+++ b/src/actions/getCartList.ts
@@ -6,11 +6,10 @@ import { Database } from "@/src/types/SupabaseTypes";
 import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
 
 export const getCartList = async () => {
-  const supabaseServerClient = createServerComponentClient<Database>({ cookies });
-
+  const cookieStore = cookies();
   const {
     data: { session },
-  } = await supabaseServerClient.auth.getSession();
+  } = await createServerComponentClient<Database>({ cookies: () => cookieStore }).auth.getSession();
 
   if (!session) redirect("/login");
 

--- a/src/actions/getCartList.ts
+++ b/src/actions/getCartList.ts
@@ -1,10 +1,9 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
+import { prisma } from "@/src/lib/prisma";
+import { Database } from "@/src/types/SupabaseTypes";
 import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
-
-import { prisma } from "../lib/prisma";
-import { Database } from "../types/SupabaseTypes";
 
 export const getCartList = async () => {
   const supabaseServerClient = createServerComponentClient<Database>({ cookies });

--- a/src/actions/getChefById.ts
+++ b/src/actions/getChefById.ts
@@ -1,10 +1,9 @@
 import { cookies } from "next/headers";
 import { notFound, redirect } from "next/navigation";
 
+import { prisma } from "@/src/lib/prisma";
+import { Database } from "@/src/types/SupabaseTypes";
 import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
-
-import { prisma } from "../lib/prisma";
-import { Database } from "../types/SupabaseTypes";
 
 export const getChefById = async ({ id, orderByLikes = false }: { id: string; orderByLikes?: boolean }) => {
   const chef = await prisma.user.findUnique({

--- a/src/actions/getChefById.ts
+++ b/src/actions/getChefById.ts
@@ -41,11 +41,10 @@ export const getChefById = async ({ id, orderByLikes = false }: { id: string; or
     chef.Recipe.sort((a, b) => (b._count.likes || 0) - (a._count.likes || 0));
   }
 
-  const supabaseServerClient = createServerComponentClient<Database>({ cookies });
-
+  const cookieStore = cookies();
   const {
     data: { session },
-  } = await supabaseServerClient.auth.getSession();
+  } = await createServerComponentClient<Database>({ cookies: () => cookieStore }).auth.getSession();
 
   if (!session) redirect("/login");
 

--- a/src/actions/getChefs.ts
+++ b/src/actions/getChefs.ts
@@ -1,4 +1,4 @@
-import { prisma } from "../lib/prisma";
+import { prisma } from "@/src/lib/prisma";
 
 export const getChefs = async () => {
   const chefs = await prisma.user.findMany({

--- a/src/actions/getChefsInMyFollowingList.ts
+++ b/src/actions/getChefsInMyFollowingList.ts
@@ -7,11 +7,10 @@ import { prisma } from "../lib/prisma";
 import { Database } from "../types/SupabaseTypes";
 
 export const getChefsInMyFollowingList = async () => {
-  const supabaseServerClient = createServerComponentClient<Database>({ cookies });
-
+  const cookieStore = cookies();
   const {
     data: { session },
-  } = await supabaseServerClient.auth.getSession();
+  } = await createServerComponentClient<Database>({ cookies: () => cookieStore }).auth.getSession();
 
   if (!session) redirect("/login");
 

--- a/src/actions/getChefsInMyFollowingList.ts
+++ b/src/actions/getChefsInMyFollowingList.ts
@@ -6,7 +6,7 @@ import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
 import { prisma } from "../lib/prisma";
 import { Database } from "../types/SupabaseTypes";
 
-export const getFollowingChefs = async () => {
+export const getChefsInMyFollowingList = async () => {
   const supabaseServerClient = createServerComponentClient<Database>({ cookies });
 
   const {

--- a/src/actions/getChefsTopFollowersInLast3Days.ts
+++ b/src/actions/getChefsTopFollowersInLast3Days.ts
@@ -2,7 +2,7 @@ import { addDays } from "date-fns";
 
 import { prisma } from "../lib/prisma";
 
-export const getTopFollowersInLast3Days = async () => {
+export const getChefsWithTopFollowersInLast3Days = async () => {
   const threeDaysAgo = addDays(new Date(), -3);
 
   const followers = await prisma.userFollower.groupBy({

--- a/src/actions/getDraftRecipe.ts
+++ b/src/actions/getDraftRecipe.ts
@@ -1,4 +1,4 @@
-import { prisma } from "../lib/prisma";
+import { prisma } from "@/src/lib/prisma";
 
 export const getDraftRecipe = async (id: string) => {
   const draftRecipe = await prisma.draftRecipe.findUnique({

--- a/src/actions/getDraftRecipes.ts
+++ b/src/actions/getDraftRecipes.ts
@@ -6,11 +6,10 @@ import { Database } from "@/src/types/SupabaseTypes";
 import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
 
 export const getDraftRecipes = async () => {
-  const supabaseServerClient = createServerComponentClient<Database>({ cookies });
-
+  const cookieStore = cookies();
   const {
     data: { session },
-  } = await supabaseServerClient.auth.getSession();
+  } = await createServerComponentClient<Database>({ cookies: () => cookieStore }).auth.getSession();
 
   if (!session) redirect("/login");
 

--- a/src/actions/getDraftRecipes.ts
+++ b/src/actions/getDraftRecipes.ts
@@ -1,10 +1,9 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
+import { prisma } from "@/src/lib/prisma";
+import { Database } from "@/src/types/SupabaseTypes";
 import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
-
-import { prisma } from "../lib/prisma";
-import { Database } from "../types/SupabaseTypes";
 
 export const getDraftRecipes = async () => {
   const supabaseServerClient = createServerComponentClient<Database>({ cookies });

--- a/src/actions/getMemos.ts
+++ b/src/actions/getMemos.ts
@@ -1,10 +1,9 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
+import { prisma } from "@/src/lib/prisma";
+import { Database } from "@/src/types/SupabaseTypes";
 import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
-
-import { prisma } from "../lib/prisma";
-import { Database } from "../types/SupabaseTypes";
 
 export const getMemos = async () => {
   const supabaseServerClient = createServerComponentClient<Database>({ cookies });

--- a/src/actions/getMemos.ts
+++ b/src/actions/getMemos.ts
@@ -6,11 +6,10 @@ import { Database } from "@/src/types/SupabaseTypes";
 import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
 
 export const getMemos = async () => {
-  const supabaseServerClient = createServerComponentClient<Database>({ cookies });
-
+  const cookieStore = cookies();
   const {
     data: { session },
-  } = await supabaseServerClient.auth.getSession();
+  } = await createServerComponentClient<Database>({ cookies: () => cookieStore }).auth.getSession();
 
   if (!session) redirect("/login");
 

--- a/src/actions/getMyRecipes.ts
+++ b/src/actions/getMyRecipes.ts
@@ -13,11 +13,10 @@ export const getMyRecipes = async (
     limit: undefined,
   }
 ) => {
-  const supabaseServerClient = createServerComponentClient<Database>({ cookies });
-
+  const cookieStore = cookies();
   const {
     data: { session },
-  } = await supabaseServerClient.auth.getSession();
+  } = await createServerComponentClient<Database>({ cookies: () => cookieStore }).auth.getSession();
 
   if (!session) redirect("/login");
 

--- a/src/actions/getMyRecipes.ts
+++ b/src/actions/getMyRecipes.ts
@@ -1,12 +1,10 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
+import { prisma } from "@/src/lib/prisma";
+import { PaginationParams } from "@/src/types/PaginationParams";
+import { Database } from "@/src/types/SupabaseTypes";
 import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
-
-import { kInfiniteScrollCount } from "../constants/constants";
-import { prisma } from "../lib/prisma";
-import { PaginationParams } from "../types/PaginationParams";
-import { Database } from "../types/SupabaseTypes";
 
 export const getMyRecipes = async (
   { orderByLikes, limit, skip }: { orderByLikes?: boolean } & PaginationParams = {

--- a/src/actions/getRecipeById.ts
+++ b/src/actions/getRecipeById.ts
@@ -6,11 +6,10 @@ import { Database } from "@/src/types/SupabaseTypes";
 import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
 
 export const getRecipeById = async (id: string) => {
-  const supabaseServerClient = createServerComponentClient<Database>({ cookies });
-
+  const cookieStore = cookies();
   const {
     data: { session },
-  } = await supabaseServerClient.auth.getSession();
+  } = await createServerComponentClient<Database>({ cookies: () => cookieStore }).auth.getSession();
 
   if (!session) redirect("/login");
 

--- a/src/actions/getRecipeById.ts
+++ b/src/actions/getRecipeById.ts
@@ -1,10 +1,9 @@
 import { cookies } from "next/headers";
 import { notFound, redirect } from "next/navigation";
 
+import { prisma } from "@/src/lib/prisma";
+import { Database } from "@/src/types/SupabaseTypes";
 import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
-
-import { prisma } from "../lib/prisma";
-import { Database } from "../types/SupabaseTypes";
 
 export const getRecipeById = async (id: string) => {
   const supabaseServerClient = createServerComponentClient<Database>({ cookies });

--- a/src/actions/getRecipes.ts
+++ b/src/actions/getRecipes.ts
@@ -16,6 +16,11 @@ export const getRecipes = async (
     orderBy: {
       createdAt: "desc",
     },
+    where: {
+      user: {
+        role: "CHEF",
+      },
+    },
     skip,
     take: limit,
   });

--- a/src/actions/getRecipes.ts
+++ b/src/actions/getRecipes.ts
@@ -1,6 +1,6 @@
-import { kInfiniteScrollCount } from "../constants/constants";
-import { prisma } from "../lib/prisma";
-import { PaginationParams } from "../types/PaginationParams";
+import { kInfiniteScrollCount } from "@/src/constants/constants";
+import { prisma } from "@/src/lib/prisma";
+import { PaginationParams } from "@/src/types/PaginationParams";
 
 export const getRecipes = async (
   { skip, limit }: PaginationParams = {

--- a/src/actions/getRecipesInMyFavorites.ts
+++ b/src/actions/getRecipesInMyFavorites.ts
@@ -1,14 +1,13 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
+import { kInfiniteScrollCount } from "@/src/constants/constants";
+import { prisma } from "@/src/lib/prisma";
+import { PaginationParams } from "@/src/types/PaginationParams";
+import { Database } from "@/src/types/SupabaseTypes";
 import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
 
-import { kInfiniteScrollCount } from "../constants/constants";
-import { prisma } from "../lib/prisma";
-import { PaginationParams } from "../types/PaginationParams";
-import { Database } from "../types/SupabaseTypes";
-
-export const getMyFavoriteRecipes = async (
+export const getRecipesInMyFavorites = async (
   { skip, limit }: PaginationParams = {
     skip: 0,
     limit: kInfiniteScrollCount,
@@ -25,6 +24,10 @@ export const getMyFavoriteRecipes = async (
   const favoriteRecipes = await prisma.favorite.findMany({
     where: {
       userId: session.user.id,
+      recipe: {
+        // マイレシピは非公開のものも含めて取得する
+        OR: [{ isPublished: true }, { userId: session.user.id }],
+      },
     },
     include: {
       recipe: {

--- a/src/actions/getRecipesInMyFavorites.ts
+++ b/src/actions/getRecipesInMyFavorites.ts
@@ -13,11 +13,10 @@ export const getRecipesInMyFavorites = async (
     limit: kInfiniteScrollCount,
   }
 ) => {
-  const supabaseServerClient = createServerComponentClient<Database>({ cookies });
-
+  const cookieStore = cookies();
   const {
     data: { session },
-  } = await supabaseServerClient.auth.getSession();
+  } = await createServerComponentClient<Database>({ cookies: () => cookieStore }).auth.getSession();
 
   if (!session) redirect("/login");
 

--- a/src/actions/getRecipesNewFromFollowedChefs.ts
+++ b/src/actions/getRecipesNewFromFollowedChefs.ts
@@ -13,11 +13,10 @@ export const getRecipesNewFromFollowedChefs = async (
     limit: kInfiniteScrollCount,
   }
 ) => {
-  const supabaseServerClient = createServerComponentClient<Database>({ cookies });
-
+  const cookieStore = cookies();
   const {
     data: { session },
-  } = await supabaseServerClient.auth.getSession();
+  } = await createServerComponentClient<Database>({ cookies: () => cookieStore }).auth.getSession();
 
   if (!session) redirect("/login");
 

--- a/src/actions/getRecipesNewFromFollowedChefs.ts
+++ b/src/actions/getRecipesNewFromFollowedChefs.ts
@@ -1,14 +1,13 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
+import { kInfiniteScrollCount } from "@/src/constants/constants";
+import { prisma } from "@/src/lib/prisma";
+import { PaginationParams } from "@/src/types/PaginationParams";
+import { Database } from "@/src/types/SupabaseTypes";
 import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
 
-import { kInfiniteScrollCount } from "../constants/constants";
-import { prisma } from "../lib/prisma";
-import { PaginationParams } from "../types/PaginationParams";
-import { Database } from "../types/SupabaseTypes";
-
-export const getNewRecipesFromFollowingChefs = async (
+export const getRecipesNewFromFollowedChefs = async (
   { limit, skip }: PaginationParams = {
     skip: 0,
     limit: kInfiniteScrollCount,

--- a/src/actions/getRecipesTopFavoritesInLast3Days.ts
+++ b/src/actions/getRecipesTopFavoritesInLast3Days.ts
@@ -1,10 +1,9 @@
+import { kInfiniteScrollCount } from "@/src/constants/constants";
+import { prisma } from "@/src/lib/prisma";
+import { PaginationParams } from "@/src/types/PaginationParams";
 import { addDays } from "date-fns";
 
-import { kInfiniteScrollCount } from "../constants/constants";
-import { prisma } from "../lib/prisma";
-import { PaginationParams } from "../types/PaginationParams";
-
-export const getTopFavoriteRecipesInLast3Days = async (
+export const getRecipesTopFavoritesInLast3Days = async (
   { limit, skip }: PaginationParams = {
     skip: 0,
     limit: kInfiniteScrollCount,

--- a/src/actions/getTopFavoriteRecipesInLast3Days.ts
+++ b/src/actions/getTopFavoriteRecipesInLast3Days.ts
@@ -38,6 +38,9 @@ export const getTopFavoriteRecipesInLast3Days = async (
       id: {
         in: recipeIds,
       },
+      user: {
+        role: "CHEF",
+      },
     },
     include: {
       RecipeImage: true,

--- a/src/actions/patchRecipePublishStatus.ts
+++ b/src/actions/patchRecipePublishStatus.ts
@@ -1,0 +1,58 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { prisma } from "@/src/lib/prisma";
+import { ActionsResult } from "@/src/types/ActionsResult";
+
+export const patchRecipePublishStatus = async (id: string): Promise<ActionsResult> => {
+  try {
+    const currentRecipe = await prisma.recipe.findUnique({
+      where: {
+        id,
+      },
+      select: {
+        isPublished: true,
+      },
+    });
+
+    if (!currentRecipe) {
+      return {
+        isSuccess: false,
+        error: "レシピの取得に失敗しました🥲",
+      };
+    }
+
+    const updatedRecipe = await prisma.recipe.update({
+      where: {
+        id,
+      },
+      data: {
+        isPublished: !currentRecipe.isPublished,
+      },
+      select: {
+        isPublished: true,
+      },
+    });
+
+    if (!updatedRecipe) {
+      return {
+        isSuccess: false,
+        error: "レシピの更新に失敗しました🥲",
+      };
+    }
+
+    revalidatePath(`/my-recipe/${id}`);
+
+    return {
+      isSuccess: true,
+      message: `レシピの公開状態を${updatedRecipe.isPublished ? "「公開」" : "「非公開」"}に変更しました🎉`,
+    };
+  } catch (error) {
+    console.log(error);
+    return {
+      isSuccess: false,
+      error: "レシピの公開状態の変更に失敗しました🥲",
+    };
+  }
+};

--- a/src/actions/postAllToCart.ts
+++ b/src/actions/postAllToCart.ts
@@ -4,11 +4,10 @@ import { revalidatePath } from "next/cache";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
+import { prisma } from "@/src/lib/prisma";
+import { ActionsResult } from "@/src/types/ActionsResult";
+import { Database } from "@/src/types/SupabaseTypes";
 import { createServerActionClient } from "@supabase/auth-helpers-nextjs";
-
-import { prisma } from "../lib/prisma";
-import { ActionsResult } from "../types/ActionsResult";
-import { Database } from "../types/SupabaseTypes";
 
 export const postAllToCart = async (recipeId: string, ingredientIds: number[]): Promise<ActionsResult> => {
   const supabaseServerClient = createServerActionClient<Database>({ cookies });

--- a/src/actions/postAllToCart.ts
+++ b/src/actions/postAllToCart.ts
@@ -10,11 +10,10 @@ import { Database } from "@/src/types/SupabaseTypes";
 import { createServerActionClient } from "@supabase/auth-helpers-nextjs";
 
 export const postAllToCart = async (recipeId: string, ingredientIds: number[]): Promise<ActionsResult> => {
-  const supabaseServerClient = createServerActionClient<Database>({ cookies });
-
+  const cookieStore = cookies();
   const {
     data: { session },
-  } = await supabaseServerClient.auth.getSession();
+  } = await createServerActionClient<Database>({ cookies: () => cookieStore }).auth.getSession();
 
   if (!session) redirect("/login");
 

--- a/src/actions/postChef.ts
+++ b/src/actions/postChef.ts
@@ -2,11 +2,10 @@
 
 import { revalidatePath } from "next/cache";
 
+import { createChefFormSchema } from "@/src/app/admin/(chefs)/_components/create-chef-form";
 import { prisma } from "@/src/lib/prisma";
+import { ActionsResult } from "@/src/types/ActionsResult";
 import { zact } from "zact/server";
-
-import { createChefFormSchema } from "../app/admin/(chefs)/_components/create-chef-form";
-import { ActionsResult } from "../types/ActionsResult";
 
 export const postChef = zact(createChefFormSchema)(async ({ name, bio, urls }): Promise<ActionsResult> => {
   try {

--- a/src/actions/postDraftRecipe.ts
+++ b/src/actions/postDraftRecipe.ts
@@ -2,11 +2,10 @@
 
 import { revalidatePath } from "next/cache";
 
+import { createDraftRecipeFormSchema } from "@/src/components/create-recipe-form/schema";
 import { prisma } from "@/src/lib/prisma";
+import { ActionsResult } from "@/src/types/ActionsResult";
 import { zact } from "zact/server";
-
-import { createDraftRecipeFormSchema } from "../components/create-recipe-form/schema";
-import { ActionsResult } from "../types/ActionsResult";
 
 export const postDraftRecipe = zact(createDraftRecipeFormSchema)(
   async ({ uid, title, bio, ingredients, urls, servingCount, instructions, recipeImage }): Promise<ActionsResult> => {

--- a/src/actions/postMemo.ts
+++ b/src/actions/postMemo.ts
@@ -9,11 +9,10 @@ import { Database } from "@/src/types/SupabaseTypes";
 import { createServerActionClient } from "@supabase/auth-helpers-nextjs";
 
 export const postMemo = async (formData: FormData): Promise<ActionsResult> => {
-  const supabaseServerClient = createServerActionClient<Database>({ cookies });
-
+  const cookieStore = cookies();
   const {
     data: { session },
-  } = await supabaseServerClient.auth.getSession();
+  } = await createServerActionClient<Database>({ cookies: () => cookieStore }).auth.getSession();
 
   if (!session) redirect("/login");
 

--- a/src/actions/postMemo.ts
+++ b/src/actions/postMemo.ts
@@ -1,14 +1,12 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
+import { prisma } from "@/src/lib/prisma";
+import { ActionsResult } from "@/src/types/ActionsResult";
+import { Database } from "@/src/types/SupabaseTypes";
 import { createServerActionClient } from "@supabase/auth-helpers-nextjs";
-
-import { prisma } from "../lib/prisma";
-import { ActionsResult } from "../types/ActionsResult";
-import { Database } from "../types/SupabaseTypes";
 
 export const postMemo = async (formData: FormData): Promise<ActionsResult> => {
   const supabaseServerClient = createServerActionClient<Database>({ cookies });

--- a/src/actions/postRecipe.ts
+++ b/src/actions/postRecipe.ts
@@ -1,26 +1,16 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { cookies } from "next/headers";
-import { redirect } from "next/navigation";
 
+import { getAuthenticatedUser } from "@/src/actions/getAuthenticatedUser";
+import { createRecipeFormSchema } from "@/src/components/create-recipe-form";
 import { prisma } from "@/src/lib/prisma";
-import { createServerActionClient } from "@supabase/auth-helpers-nextjs";
+import { ActionsResult } from "@/src/types/ActionsResult";
 import { zact } from "zact/server";
-
-import { createRecipeFormSchema } from "../components/create-recipe-form";
-import { ActionsResult } from "../types/ActionsResult";
-import { Database } from "../types/SupabaseTypes";
 
 export const postRecipe = zact(createRecipeFormSchema)(
   async ({ uid, title, bio, ingredients, urls, servingCount, instructions, recipeImage }): Promise<ActionsResult> => {
-    const supabaseServerClient = createServerActionClient<Database>({ cookies });
-
-    const {
-      data: { session },
-    } = await supabaseServerClient.auth.getSession();
-
-    if (!session) redirect("/login");
+    const user = await getAuthenticatedUser();
 
     try {
       await prisma.recipe.create({
@@ -29,6 +19,8 @@ export const postRecipe = zact(createRecipeFormSchema)(
           description: bio,
           userId: uid,
           servingCount: servingCount,
+          // 管理者が作成した場合（シェフのレシピ）は公開状態にする
+          isPublished: user?.role === "ADMIN",
           RecipeImage: {
             create: {
               recipeImage: recipeImage ?? "",

--- a/src/actions/postUser.ts
+++ b/src/actions/postUser.ts
@@ -2,8 +2,8 @@
 
 import { revalidatePath } from "next/cache";
 
-import { prisma } from "../lib/prisma";
-import { ActionsResult } from "../types/ActionsResult";
+import { prisma } from "@/src/lib/prisma";
+import { ActionsResult } from "@/src/types/ActionsResult";
 
 export const postUser = async ({ id, name }: { id?: string; name: string }): Promise<ActionsResult> => {
   try {

--- a/src/actions/putChef.ts
+++ b/src/actions/putChef.ts
@@ -2,11 +2,10 @@
 
 import { revalidatePath } from "next/cache";
 
+import { editChefFormSchema } from "@/src/app/admin/(chefs)/_components/edit-chef-form";
 import { prisma } from "@/src/lib/prisma";
+import { ActionsResult } from "@/src/types/ActionsResult";
 import { zact } from "zact/server";
-
-import { editChefFormSchema } from "../app/admin/(chefs)/_components/edit-chef-form";
-import { ActionsResult } from "../types/ActionsResult";
 
 export const putChef = zact(editChefFormSchema)(async ({ uid, name, bio, urls }): Promise<ActionsResult> => {
   const currentUserLinks = await prisma.userLink.findMany({

--- a/src/actions/putMemo.ts
+++ b/src/actions/putMemo.ts
@@ -10,11 +10,10 @@ import { Database } from "@/src/types/SupabaseTypes";
 import { createServerActionClient } from "@supabase/auth-helpers-nextjs";
 
 export const putMemo = async (id: number, isCompleted: boolean): Promise<ActionsResult> => {
-  const supabaseServerClient = createServerActionClient<Database>({ cookies });
-
+  const cookieStore = cookies();
   const {
     data: { session },
-  } = await supabaseServerClient.auth.getSession();
+  } = await createServerActionClient<Database>({ cookies: () => cookieStore }).auth.getSession();
 
   if (!session) redirect("/login");
 

--- a/src/actions/putMemo.ts
+++ b/src/actions/putMemo.ts
@@ -4,11 +4,10 @@ import { revalidatePath } from "next/cache";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
+import { prisma } from "@/src/lib/prisma";
+import { ActionsResult } from "@/src/types/ActionsResult";
+import { Database } from "@/src/types/SupabaseTypes";
 import { createServerActionClient } from "@supabase/auth-helpers-nextjs";
-
-import { prisma } from "../lib/prisma";
-import { ActionsResult } from "../types/ActionsResult";
-import { Database } from "../types/SupabaseTypes";
 
 export const putMemo = async (id: number, isCompleted: boolean): Promise<ActionsResult> => {
   const supabaseServerClient = createServerActionClient<Database>({ cookies });

--- a/src/actions/putProfile.ts
+++ b/src/actions/putProfile.ts
@@ -4,13 +4,12 @@ import { revalidatePath } from "next/cache";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
+import { editProfileFormSchema } from "@/src/app/my-page/edit/_components/edit-profile-form/schema";
 import { prisma } from "@/src/lib/prisma";
+import { ActionsResult } from "@/src/types/ActionsResult";
+import { Database } from "@/src/types/SupabaseTypes";
 import { createServerActionClient } from "@supabase/auth-helpers-nextjs";
 import { zact } from "zact/server";
-
-import { editProfileFormSchema } from "../app/my-page/edit/_components/edit-profile-form/schema";
-import { ActionsResult } from "../types/ActionsResult";
-import { Database } from "../types/SupabaseTypes";
 
 export const putProfile = zact(editProfileFormSchema)(async ({ nickName, bio, urls }): Promise<ActionsResult> => {
   const supabaseServerClient = createServerActionClient<Database>({ cookies });

--- a/src/actions/putProfile.ts
+++ b/src/actions/putProfile.ts
@@ -12,11 +12,10 @@ import { createServerActionClient } from "@supabase/auth-helpers-nextjs";
 import { zact } from "zact/server";
 
 export const putProfile = zact(editProfileFormSchema)(async ({ nickName, bio, urls }): Promise<ActionsResult> => {
-  const supabaseServerClient = createServerActionClient<Database>({ cookies });
-
+  const cookieStore = cookies();
   const {
     data: { session },
-  } = await supabaseServerClient.auth.getSession();
+  } = await createServerActionClient<Database>({ cookies: () => cookieStore }).auth.getSession();
 
   if (!session) redirect("/login");
 

--- a/src/actions/putRecipe.ts
+++ b/src/actions/putRecipe.ts
@@ -15,11 +15,10 @@ import { zact } from "zact/server";
 
 export const putRecipe = zact(editRecipeFormSchema)(
   async ({ recipeId, title, bio, ingredients, urls, servingCount, instructions }): Promise<ActionsResult> => {
-    const supabaseServerClient = createServerActionClient<Database>({ cookies });
-
+    const cookieStore = cookies();
     const {
       data: { session },
-    } = await supabaseServerClient.auth.getSession();
+    } = await createServerActionClient<Database>({ cookies: () => cookieStore }).auth.getSession();
 
     if (!session) redirect("/login");
 

--- a/src/actions/putRecipe.ts
+++ b/src/actions/putRecipe.ts
@@ -4,15 +4,14 @@ import { revalidatePath } from "next/cache";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
+import { editRecipeFormSchema } from "@/src/app/my-recipe/(_)/[id]/edit/_components/edit-recipe-form";
+import { EditRecipeFormValues } from "@/src/app/my-recipe/(_)/[id]/edit/_components/edit-recipe-form/schema";
 import { prisma } from "@/src/lib/prisma";
+import { ActionsResult } from "@/src/types/ActionsResult";
+import { Database } from "@/src/types/SupabaseTypes";
 import { Ingredient, Instruction, RecipeLink } from "@prisma/client";
 import { createServerActionClient } from "@supabase/auth-helpers-nextjs";
 import { zact } from "zact/server";
-
-import { editRecipeFormSchema } from "../app/my-recipe/(_)/[id]/edit/_components/edit-recipe-form";
-import { EditRecipeFormValues } from "../app/my-recipe/(_)/[id]/edit/_components/edit-recipe-form/schema";
-import { ActionsResult } from "../types/ActionsResult";
-import { Database } from "../types/SupabaseTypes";
 
 export const putRecipe = zact(editRecipeFormSchema)(
   async ({ recipeId, title, bio, ingredients, urls, servingCount, instructions }): Promise<ActionsResult> => {

--- a/src/actions/searchRecipesAndChefs.ts
+++ b/src/actions/searchRecipesAndChefs.ts
@@ -1,8 +1,8 @@
-import { kInfiniteScrollCount } from "../constants/constants";
-import { prisma } from "../lib/prisma";
-import { PaginationParams } from "../types/PaginationParams";
-import { getChefs } from "./getChefs";
-import { getTopFavoriteRecipesInLast3Days } from "./getTopFavoriteRecipesInLast3Days";
+import { getChefs } from "@/src/actions/getChefs";
+import { getRecipesTopFavoritesInLast3Days } from "@/src/actions/getRecipesTopFavoritesInLast3Days";
+import { kInfiniteScrollCount } from "@/src/constants/constants";
+import { prisma } from "@/src/lib/prisma";
+import { PaginationParams } from "@/src/types/PaginationParams";
 
 export const searchRecipesAndChefs = async (
   searchQuery: string,
@@ -12,7 +12,7 @@ export const searchRecipesAndChefs = async (
   }
 ) => {
   if (!searchQuery) {
-    const topFavoriteRecipes = await getTopFavoriteRecipesInLast3Days({ limit, skip });
+    const topFavoriteRecipes = await getRecipesTopFavoritesInLast3Days({ limit, skip });
 
     const { chefs } = await getChefs();
 

--- a/src/actions/searchRecipesAndChefs.ts
+++ b/src/actions/searchRecipesAndChefs.ts
@@ -1,6 +1,8 @@
 import { kInfiniteScrollCount } from "../constants/constants";
 import { prisma } from "../lib/prisma";
 import { PaginationParams } from "../types/PaginationParams";
+import { getChefs } from "./getChefs";
+import { getTopFavoriteRecipesInLast3Days } from "./getTopFavoriteRecipesInLast3Days";
 
 export const searchRecipesAndChefs = async (
   searchQuery: string,
@@ -9,6 +11,24 @@ export const searchRecipesAndChefs = async (
     limit: kInfiniteScrollCount,
   }
 ) => {
+  if (!searchQuery) {
+    const topFavoriteRecipes = await getTopFavoriteRecipesInLast3Days({ limit, skip });
+
+    const { chefs } = await getChefs();
+
+    return {
+      searchedRecipes: topFavoriteRecipes.map((recipe) => ({
+        ...recipe,
+        _count: {
+          likes: recipe.likeCount,
+        },
+      })),
+      searchedChefs: chefs,
+      totalRecipes: topFavoriteRecipes.length,
+      totalChefs: 0,
+    };
+  }
+
   const search = searchQuery.toLowerCase();
 
   const [filteredRecipes, filteredChefs] = await Promise.all([
@@ -25,6 +45,9 @@ export const searchRecipesAndChefs = async (
         createdAt: "desc",
       },
       where: {
+        user: {
+          role: "CHEF",
+        },
         OR: [
           {
             title: {
@@ -73,6 +96,9 @@ export const searchRecipesAndChefs = async (
   const [totalRecipes, totalChefs] = await Promise.all([
     prisma.recipe.count({
       where: {
+        user: {
+          role: "CHEF",
+        },
         OR: [
           {
             title: {

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -16,9 +16,7 @@ const LoginPage = async () => {
     data: { session },
   } = await supabase.auth.getSession();
 
-  if (session) {
-    redirect("/");
-  }
+  if (session) redirect("/");
 
   const defaultValues: LoginFormValues = {
     email: "",

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -8,13 +8,10 @@ import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
 import { LoginForm, LoginFormValues } from "./_components";
 
 const LoginPage = async () => {
-  const supabase = createServerComponentClient<Database>({
-    cookies,
-  });
-
+  const cookieStore = cookies();
   const {
     data: { session },
-  } = await supabase.auth.getSession();
+  } = await createServerComponentClient<Database>({ cookies: () => cookieStore }).auth.getSession();
 
   if (session) redirect("/");
 

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -8,13 +8,10 @@ import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
 import SignUpForm from "./_components/signup-form";
 
 const SignUpPage = async () => {
-  const supabase = createServerComponentClient<Database>({
-    cookies,
-  });
-
+  const cookieStore = cookies();
   const {
     data: { session },
-  } = await supabase.auth.getSession();
+  } = await createServerComponentClient<Database>({ cookies: () => cookieStore }).auth.getSession();
 
   if (session) {
     redirect("/");

--- a/src/app/(root)/_components/horizontal-top-favorite-recipes-in-last-3days-list.tsx
+++ b/src/app/(root)/_components/horizontal-top-favorite-recipes-in-last-3days-list.tsx
@@ -1,26 +1,29 @@
-import { getTopFavoriteRecipesInLast3Days } from "@/src/actions/getTopFavoriteRecipesInLast3Days";
+import { getRecipesTopFavoritesInLast3Days } from "@/src/actions/getRecipesTopFavoritesInLast3Days";
 import NoDataDisplay from "@/src/components/no-data-display";
 import RecipeCard from "@/src/components/recipe-card";
 
 const HorizontalTopFavoriteRecipesInLast3DaysList = async () => {
-  const topFavoriteRecipesInLast3Days = await getTopFavoriteRecipesInLast3Days({ limit: 10 });
+  const topFavoriteRecipesInLast3Days = await getRecipesTopFavoritesInLast3Days({ limit: 10 });
 
   return (
     <>
       {topFavoriteRecipesInLast3Days.length > 0 ? (
         <ul className="mt-2 flex w-screen gap-x-2 overflow-x-scroll px-4 md:w-full">
-          {topFavoriteRecipesInLast3Days.map(({ id, title, description, RecipeImage, likes, likeCount }) => (
-            <li key={id} className="flex w-[160px] flex-none flex-col">
-              <RecipeCard
-                title={title}
-                description={description}
-                // TODO: 画像を設定する
-                imageUrl="https://images.unsplash.com/photo-1595295333158-4742f28fbd85?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=320&q=80"
-                favorites={likeCount}
-                path={`/recipe/${id}`}
-              />
-            </li>
-          ))}
+          {topFavoriteRecipesInLast3Days.map(
+            ({ id, title, description, RecipeImage, likes, likeCount, isPublished }) => (
+              <li key={id} className="flex w-[160px] flex-none flex-col">
+                <RecipeCard
+                  isPublished={isPublished}
+                  title={title}
+                  description={description}
+                  // TODO: 画像を設定する
+                  imageUrl="https://images.unsplash.com/photo-1595295333158-4742f28fbd85?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=320&q=80"
+                  favorites={likeCount}
+                  path={`/recipe/${id}`}
+                />
+              </li>
+            )
+          )}
         </ul>
       ) : (
         <NoDataDisplay text="過去３日間でお気に入り登録されたレシピはありません。" />

--- a/src/app/(root)/_components/horizontal-top-favorite-recipes-in-last-3days-list.tsx
+++ b/src/app/(root)/_components/horizontal-top-favorite-recipes-in-last-3days-list.tsx
@@ -3,7 +3,7 @@ import NoDataDisplay from "@/src/components/no-data-display";
 import RecipeCard from "@/src/components/recipe-card";
 
 const HorizontalTopFavoriteRecipesInLast3DaysList = async () => {
-  const topFavoriteRecipesInLast3Days = await getTopFavoriteRecipesInLast3Days({ limit: 5 });
+  const topFavoriteRecipesInLast3Days = await getTopFavoriteRecipesInLast3Days({ limit: 10 });
 
   return (
     <>

--- a/src/app/(root)/_components/horizontal-top-follow-chefs-in-last-3days-list.tsx
+++ b/src/app/(root)/_components/horizontal-top-follow-chefs-in-last-3days-list.tsx
@@ -1,9 +1,9 @@
-import { getTopFollowersInLast3Days } from "@/src/actions/getTopFollowersInLast3Days";
+import { getChefsWithTopFollowersInLast3Days } from "@/src/actions/getChefsTopFollowersInLast3Days";
 import { ChefCard } from "@/src/components/chef-card";
 import NoDataDisplay from "@/src/components/no-data-display";
 
 const HorizontalTopFollowChefsInLast3DaysList = async () => {
-  const topFollowersInLast3Days = await getTopFollowersInLast3Days();
+  const topFollowersInLast3Days = await getChefsWithTopFollowersInLast3Days();
 
   return (
     <>

--- a/src/app/(root)/favorite/_components/horizontal-following-chefs-list.tsx
+++ b/src/app/(root)/favorite/_components/horizontal-following-chefs-list.tsx
@@ -1,11 +1,11 @@
 import Link from "next/link";
 
-import { getFollowingChefs } from "@/src/actions/getFollowingChefs";
+import { getChefsInMyFollowingList } from "@/src/actions/getChefsInMyFollowingList";
 import NoDataDisplay from "@/src/components/no-data-display";
 import { Avatar, AvatarImage } from "@/src/components/ui/avatar";
 
 const HorizontalFollowingChefsList = async () => {
-  const followingChefs = await getFollowingChefs();
+  const followingChefs = await getChefsInMyFollowingList();
 
   return (
     <>

--- a/src/app/(root)/favorite/_components/horizontal-new-recipes-list.tsx
+++ b/src/app/(root)/favorite/_components/horizontal-new-recipes-list.tsx
@@ -1,9 +1,9 @@
-import { getNewRecipesFromFollowingChefs } from "@/src/actions/getNewRecipesFromFollowingChefs";
+import { getRecipesNewFromFollowedChefs } from "@/src/actions/getRecipesNewFromFollowedChefs";
 import NoDataDisplay from "@/src/components/no-data-display";
 import RecipeCard from "@/src/components/recipe-card";
 
 const HorizontalNewRecipesList = async () => {
-  const newRecipesFromFollowingChefs = await getNewRecipesFromFollowingChefs({ limit: 5 });
+  const newRecipesFromFollowingChefs = await getRecipesNewFromFollowedChefs({ limit: 5 });
 
   return (
     <>
@@ -18,6 +18,7 @@ const HorizontalNewRecipesList = async () => {
                 imageUrl="https://images.unsplash.com/photo-1595295333158-4742f28fbd85?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=320&q=80"
                 favorites={_count.likes}
                 path={`/recipe/${id}`}
+                isPublished={true}
               />
             </li>
           ))}

--- a/src/app/(root)/favorite/_components/my-favorite-recipes-grid.tsx
+++ b/src/app/(root)/favorite/_components/my-favorite-recipes-grid.tsx
@@ -1,29 +1,32 @@
-import { getMyFavoriteRecipes } from "@/src/actions/getMyFavoriteRecipes";
+import { getRecipesInMyFavorites } from "@/src/actions/getRecipesInMyFavorites";
 import LoadMore from "@/src/components/load-more";
 import NoDataDisplay from "@/src/components/no-data-display";
 import RecipeList from "@/src/components/recipe-list";
 import { kInfiniteScrollCount } from "@/src/constants/constants";
 
 const MyFavoriteRecipesGrid = async () => {
-  const initMyFavoriteRecipes = await getMyFavoriteRecipes();
+  const initMyFavoriteRecipes = await getRecipesInMyFavorites();
 
   const loadMoreMyFavoriteRecipes = async (offset: number = 0) => {
     "use server";
 
-    const myRecipes = await getMyFavoriteRecipes({
+    const myRecipes = await getRecipesInMyFavorites({
       skip: offset + kInfiniteScrollCount,
     });
 
     const nextOffset = offset + myRecipes.length;
 
-    return [myRecipes.map((recipe) => <RecipeList key={recipe.id} recipes={[recipe]} />), nextOffset] as const;
+    return [
+      myRecipes.map((recipe) => <RecipeList key={recipe.id} recipes={[recipe]} segment="recipe" />),
+      nextOffset,
+    ] as const;
   };
 
   return (
     <>
       {initMyFavoriteRecipes.length > 0 ? (
         <LoadMore initialOffset={0} loadMoreAction={loadMoreMyFavoriteRecipes}>
-          <RecipeList recipes={initMyFavoriteRecipes} />
+          <RecipeList recipes={initMyFavoriteRecipes} segment="recipe" />
         </LoadMore>
       ) : (
         <NoDataDisplay text="まだお気に入りのレシピはありません。" />

--- a/src/app/admin/(chefs)/create/page.tsx
+++ b/src/app/admin/(chefs)/create/page.tsx
@@ -1,6 +1,3 @@
-import { redirect } from "next/navigation";
-
-import { getAuthenticatedUser } from "@/src/actions/getAuthenticatedUser";
 import TopBar from "@/src/components/layout/top-bar";
 
 import CreateChefForm from "../_components/create-chef-form/create-chef-form";

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -15,7 +15,9 @@ export async function GET(request: NextRequest) {
 
   if (code) {
     // Supabaseのクライアントインスタンスを作成
-    const supabase = createRouteHandlerClient<Database>({ cookies });
+    const cookieStore = cookies();
+
+    const supabase = createRouteHandlerClient<Database>({ cookies: () => cookieStore });
 
     // 認証コードをセッショントークンに交換
     await supabase.auth.exchangeCodeForSession(code);

--- a/src/app/chef/[id]/_components/user-profile-stats.tsx
+++ b/src/app/chef/[id]/_components/user-profile-stats.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { followChef, unFollowChef } from "@/src/actions/followActions";
+import { followChef, unFollowChef } from "@/src/actions/actionsForFollow";
 import NumberUnit from "@/src/components/number-unit";
 import ToggleButton from "@/src/components/toggle-button";
 import { BUTTON_NAMES } from "@/src/constants/button-names";

--- a/src/app/chef/[id]/page.tsx
+++ b/src/app/chef/[id]/page.tsx
@@ -11,7 +11,7 @@ const page = async ({ params }: { params: { id: string } }) => {
   return (
     <>
       <ul className="grid grid-cols-2 gap-4 p-4">
-        {recipes.map(({ id, likesCount, description, title }) => (
+        {recipes.map(({ id, likesCount, description, title, isPublished }) => (
           <li key={id}>
             <RecipeCard
               title={title}
@@ -19,6 +19,7 @@ const page = async ({ params }: { params: { id: string } }) => {
               imageUrl="https://images.unsplash.com/photo-1595295333158-4742f28fbd85?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=320&q=80"
               favorites={likesCount}
               path={`/recipe/${id}`}
+              isPublished={isPublished}
             />
           </li>
         ))}

--- a/src/app/chef/[id]/popular/page.tsx
+++ b/src/app/chef/[id]/popular/page.tsx
@@ -12,7 +12,7 @@ const page = async ({ params }: { params: { id: string } }) => {
   return (
     <>
       <ul className="grid grid-cols-2 gap-4 p-4">
-        {recipes.map(({ id, likesCount, description, title }) => (
+        {recipes.map(({ id, likesCount, description, title, isPublished }) => (
           <li key={id}>
             <RecipeCard
               title={title}
@@ -20,6 +20,7 @@ const page = async ({ params }: { params: { id: string } }) => {
               imageUrl="https://images.unsplash.com/photo-1595295333158-4742f28fbd85?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=320&q=80"
               favorites={likesCount}
               path={`/recipe/${id}`}
+              isPublished={isPublished}
             />
           </li>
         ))}

--- a/src/app/mock/_components/follow-button.tsx
+++ b/src/app/mock/_components/follow-button.tsx
@@ -1,4 +1,4 @@
-import { followChef, unFollowChef } from "@/src/actions/followActions";
+import { followChef, unFollowChef } from "@/src/actions/actionsForFollow";
 import ToggleButton from "@/src/components/toggle-button";
 import { BUTTON_NAMES } from "@/src/constants/button-names";
 

--- a/src/app/mock/_components/horizontal-following-chefs-list.tsx
+++ b/src/app/mock/_components/horizontal-following-chefs-list.tsx
@@ -1,9 +1,9 @@
-import { getFollowingChefs } from "@/src/actions/getFollowingChefs";
+import { getChefsInMyFollowingList } from "@/src/actions/getChefsInMyFollowingList";
 import { ChefIcon } from "@/src/components/chef-icon";
 import NoDataDisplay from "@/src/components/no-data-display";
 
 const HorizontalFollowingChefsList = async () => {
-  const chefs = await getFollowingChefs();
+  const chefs = await getChefsInMyFollowingList();
 
   return (
     <>

--- a/src/app/mock/kame/_components/add-favorite-recipe-button.tsx
+++ b/src/app/mock/kame/_components/add-favorite-recipe-button.tsx
@@ -2,7 +2,7 @@
 
 import { useTransition } from "react";
 
-import { favoriteRecipe } from "@/src/actions/favoriteRecipeActions";
+import { favoriteRecipe } from "@/src/actions/actionsForFavoriteRecipe";
 import { Button } from "@/src/components/ui/button";
 import Spinner from "@/src/components/ui/spinner";
 

--- a/src/app/mock/kame/_components/delete-favorite-recipe-button.tsx
+++ b/src/app/mock/kame/_components/delete-favorite-recipe-button.tsx
@@ -2,7 +2,7 @@
 
 import { useTransition } from "react";
 
-import { unFavoriteRecipe } from "@/src/actions/favoriteRecipeActions";
+import { unFavoriteRecipe } from "@/src/actions/actionsForFavoriteRecipe";
 import { Button } from "@/src/components/ui/button";
 import Spinner from "@/src/components/ui/spinner";
 
@@ -12,7 +12,13 @@ const DeleteFavoriteRecipeButton = ({ recipeId }: { recipeId: string }) => {
   return (
     <form>
       <input type="hidden" name="recipeId" value={recipeId} />
-      <Button formAction={(formData) => startTransition(() => unFavoriteRecipe(formData))}>
+      <Button
+        formAction={(formData) =>
+          startTransition(() => {
+            unFavoriteRecipe(recipeId);
+          })
+        }
+      >
         {isPending ? <Spinner /> : "削除"}
       </Button>
     </form>

--- a/src/app/mock/kame/page.tsx
+++ b/src/app/mock/kame/page.tsx
@@ -1,6 +1,6 @@
 import { getCartList } from "@/src/actions/getCartList";
-import { getMyFavoriteRecipes } from "@/src/actions/getMyFavoriteRecipes";
 import { getRecipes } from "@/src/actions/getRecipes";
+import { getRecipesInMyFavorites } from "@/src/actions/getRecipesInMyFavorites";
 
 import AddCartListButton from "./_components/add-cart-list-button";
 import AddFavoriteRecipeButton from "./_components/add-favorite-recipe-button";
@@ -8,7 +8,7 @@ import DeleteFavoriteRecipeButton from "./_components/delete-favorite-recipe-but
 
 const page = async () => {
   const recipes = await getRecipes();
-  const favoriteRecipes = await getMyFavoriteRecipes();
+  const favoriteRecipes = await getRecipesInMyFavorites();
   const cartList = await getCartList();
 
   return (

--- a/src/app/mock/kumabiko/_components/delete-memo-button.tsx
+++ b/src/app/mock/kumabiko/_components/delete-memo-button.tsx
@@ -9,7 +9,17 @@ import Spinner from "@/src/components/ui/spinner";
 const DeleteMemoButton = ({ id }: { id: number }) => {
   const [isPending, startTransition] = useTransition();
 
-  return <Button onClick={() => startTransition(() => deleteMemo(id))}>{isPending ? <Spinner /> : "削除"}</Button>;
+  return (
+    <Button
+      onClick={() =>
+        startTransition(() => {
+          deleteMemo(id);
+        })
+      }
+    >
+      {isPending ? <Spinner /> : "削除"}
+    </Button>
+  );
 };
 
 export default DeleteMemoButton;

--- a/src/app/mock/tsuboi/chefs/[id]/page.tsx
+++ b/src/app/mock/tsuboi/chefs/[id]/page.tsx
@@ -15,7 +15,7 @@ const page = async ({ params }: { params: { id: string } }) => {
   return (
     <>
       <div className="grid grid-cols-2 gap-4 p-4">
-        {recipes.map(({ id, likesCount, description, title }) => (
+        {recipes.map(({ id, likesCount, description, title, isPublished }) => (
           <div key={id}>
             <RecipeCard
               path={`/mock/tsuboi/${id}`}
@@ -23,6 +23,7 @@ const page = async ({ params }: { params: { id: string } }) => {
               description={description}
               title={title}
               imageUrl="https://images.unsplash.com/photo-1595295333158-4742f28fbd85?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=320&q=80"
+              isPublished={isPublished}
             />
           </div>
         ))}

--- a/src/app/mock/tsuboi/chefs/[id]/popular/page.tsx
+++ b/src/app/mock/tsuboi/chefs/[id]/popular/page.tsx
@@ -16,7 +16,7 @@ const page = async ({ params }: { params: { id: string } }) => {
   return (
     <>
       <div className="grid grid-cols-2 gap-4 p-4">
-        {recipes.map(({ id, likesCount, description, title }) => (
+        {recipes.map(({ id, likesCount, description, title, isPublished }) => (
           <div key={id}>
             <RecipeCard
               path={`/mock/tsuboi/${id}`}
@@ -24,6 +24,7 @@ const page = async ({ params }: { params: { id: string } }) => {
               description={description}
               title={title}
               imageUrl="https://images.unsplash.com/photo-1595295333158-4742f28fbd85?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=320&q=80"
+              isPublished={isPublished}
             />
           </div>
         ))}

--- a/src/app/mock/tsuboi/page.tsx
+++ b/src/app/mock/tsuboi/page.tsx
@@ -29,7 +29,8 @@ const page = async ({ searchParams }: { searchParams: { search?: string } }) => 
               <div key={recipe.id} className="flex flex-col gap-2">
                 <RecipeCard
                   path={`/mock/tsuboi/${recipe.id}`}
-                  favorites={recipe.likes.length}
+                  favorites={0}
+                  isPublished={recipe.isPublished}
                   description={recipe.description}
                   title={recipe.title}
                   imageUrl={

--- a/src/app/mock/unauthenticated/page.tsx
+++ b/src/app/mock/unauthenticated/page.tsx
@@ -5,10 +5,10 @@ import { Database } from "@/src/types/SupabaseTypes";
 import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
 
 export default async function page() {
-  const supabase = createServerComponentClient<Database>({ cookies });
+  const cookieStore = cookies();
   const {
     data: { session },
-  } = await supabase.auth.getSession();
+  } = await createServerComponentClient<Database>({ cookies: () => cookieStore }).auth.getSession();
 
   if (session) {
     redirect("/mock");

--- a/src/app/my-page/(_)/layout.tsx
+++ b/src/app/my-page/(_)/layout.tsx
@@ -24,10 +24,8 @@ export const metadata = {
 const layout = async ({ children }: { children: React.ReactNode }) => {
   const user = await getAuthenticatedUser();
 
-  if (!user) {
-    // TODO: 未ログイン時のリダイレクト先を変更する
-    redirect("/mock/unauthorized");
-  }
+  if (!user) redirect("/login");
+
   const sortedUserLinks = sortSiteLinks(user.UserLink.map((userLink) => userLink.url));
 
   const visibleLinks = sortedUserLinks.slice(0, 2);

--- a/src/app/my-page/(_)/page.tsx
+++ b/src/app/my-page/(_)/page.tsx
@@ -15,14 +15,17 @@ const page = async () => {
 
     const nextOffset = offset + myRecipes.length;
 
-    return [myRecipes.map((recipe) => <RecipeList key={recipe.id} recipes={[recipe]} />), nextOffset] as const;
+    return [
+      myRecipes.map((recipe) => <RecipeList key={recipe.id} recipes={[recipe]} segment="my-recipe" />),
+      nextOffset,
+    ] as const;
   };
 
   return (
     <>
       {initialRecipes.length > 0 ? (
         <LoadMore initialOffset={0} loadMoreAction={loadMoreMyRecipes}>
-          <RecipeList recipes={initialRecipes} />
+          <RecipeList recipes={initialRecipes} segment="my-recipe" />
         </LoadMore>
       ) : (
         <NoDataDisplay text="まだレシピが作成されていません。" />

--- a/src/app/my-page/(_)/popular/page.tsx
+++ b/src/app/my-page/(_)/popular/page.tsx
@@ -18,14 +18,17 @@ const page = async () => {
 
     const nextOffset = offset + myRecipes.length;
 
-    return [myRecipes.map((recipe) => <RecipeList key={recipe.id} recipes={[recipe]} />), nextOffset] as const;
+    return [
+      myRecipes.map((recipe) => <RecipeList key={recipe.id} recipes={[recipe]} segment="my-recipe" />),
+      nextOffset,
+    ] as const;
   };
 
   return (
     <>
       {initialRecipes.length > 0 ? (
         <LoadMore initialOffset={0} loadMoreAction={loadMoreMyRecipe}>
-          <RecipeList recipes={initialRecipes} />
+          <RecipeList recipes={initialRecipes} segment="my-recipe" />
         </LoadMore>
       ) : (
         <NoDataDisplay text="まだレシピが作成されていません。" />

--- a/src/app/my-recipe/[id]/_components/favorite-button.tsx
+++ b/src/app/my-recipe/[id]/_components/favorite-button.tsx
@@ -1,4 +1,4 @@
-import { favoriteRecipe, unFavoriteRecipe } from "@/src/actions/favoriteRecipeActions";
+import { favoriteRecipe, unFavoriteRecipe } from "@/src/actions/actionsForFavoriteRecipe";
 import ToggleButton from "@/src/components/toggle-button";
 
 type Props = {

--- a/src/app/my-recipe/[id]/_components/popover-menu.tsx
+++ b/src/app/my-recipe/[id]/_components/popover-menu.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useTransition } from "react";
+import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 
 import { deleteRecipe } from "@/src/actions/deleteRecipe";
+import { patchRecipePublishStatus } from "@/src/actions/patchRecipePublishStatus";
 import { Command, CommandItem, CommandList, CommandSeparator } from "@/src/components/ui/command";
 import { Popover, PopoverContent, PopoverTrigger } from "@/src/components/ui/popover";
 import Spinner from "@/src/components/ui/spinner";
@@ -13,9 +14,11 @@ import { CircleEllipsis, Copy, Lock, Trash } from "lucide-react";
 
 type Props = {
   recipeId: string;
+  isPublished: boolean;
 };
 
-const PopoverMenu = ({ recipeId }: Props) => {
+const PopoverMenu = ({ recipeId, isPublished }: Props) => {
+  const [isOpen, setIsOpen] = useState(false);
   const [isPending, startTransition] = useTransition();
 
   const { toast } = useToast();
@@ -23,7 +26,7 @@ const PopoverMenu = ({ recipeId }: Props) => {
   const router = useRouter();
 
   return (
-    <Popover>
+    <Popover open={isOpen} onOpenChange={setIsOpen}>
       <PopoverTrigger>
         <CircleEllipsis size={20} />
       </PopoverTrigger>
@@ -50,6 +53,8 @@ const PopoverMenu = ({ recipeId }: Props) => {
                         duration: 3000,
                       });
                     });
+
+                  setIsOpen(false);
                 }}
               >
                 <Copy className="mr-2 h-4 w-4" />
@@ -57,9 +62,33 @@ const PopoverMenu = ({ recipeId }: Props) => {
               </button>
             </CommandItem>
             <CommandItem>
-              {/* // TODO: 公開を停止するロジック実装 */}
-              <Lock className="mr-2 h-4 w-4" />
-              <span>公開を停止する</span>
+              <button
+                className="flex items-start"
+                onClick={async () => {
+                  const result = await patchRecipePublishStatus(recipeId);
+                  if (result.isSuccess) {
+                    toast({
+                      variant: "default",
+                      title: result.message,
+                      duration: kToastDuration,
+                    });
+                  } else {
+                    toast({
+                      variant: "destructive",
+                      title: result.error,
+                      duration: kToastDuration,
+                    });
+                  }
+
+                  setIsOpen(false);
+                }}
+              >
+                {isPending ? <Spinner /> : <Lock className="mr-2 h-4 w-4" />}
+                <div className="flex flex-col items-start">
+                  <span className="text-sm">{isPublished ? "公開を停止する" : "レシピを限定公開にする"}</span>
+                  {!isPublished && <p className="text-xs">URLを知っている方のみ閲覧可能</p>}
+                </div>
+              </button>
             </CommandItem>
 
             <CommandSeparator />
@@ -89,8 +118,8 @@ const PopoverMenu = ({ recipeId }: Props) => {
                   });
                 }}
               >
-                <Trash className="mr-2 h-4 w-4" />
-                <span>{isPending ? <Spinner /> : "レシピを削除する"}</span>
+                {isPending ? <Spinner /> : <Trash className="mr-2 h-4 w-4" />}
+                <span>レシピを削除する</span>
               </button>
             </CommandItem>
           </CommandList>

--- a/src/app/my-recipe/[id]/_components/recipe-hero.tsx
+++ b/src/app/my-recipe/[id]/_components/recipe-hero.tsx
@@ -13,7 +13,15 @@ type Props = {
 };
 
 const RecipeHero = async ({ id }: Props) => {
-  const { title, description, isMe, RecipeLink: recipeLinks, _count, isFavorite } = await getRecipeById(id);
+  const {
+    title,
+    description,
+    isMe,
+    RecipeLink: recipeLinks,
+    _count,
+    isFavorite,
+    isPublished,
+  } = await getRecipeById(id);
 
   const sortedRecipeLinks = sortSiteLinks(recipeLinks.map((value) => value.linkUrl));
 
@@ -41,12 +49,12 @@ const RecipeHero = async ({ id }: Props) => {
             <h6 className="text-xl font-bold text-mauve12">{title}</h6>
             <div className="ml-3 flex items-center gap-3">
               {recipeLinks && <LinkToIconRenderer links={sortedRecipeLinks.map((value) => value.url)} />}
-              {isMe && <PopoverMenu recipeId={id} />}
+              {isMe && <PopoverMenu recipeId={id} isPublished={isPublished} />}
             </div>
           </div>
           <p className="text-mauve12">{description}</p>
         </div>
-        <RecipeInfoStats recipeId={id} isActive={isFavorite} favoriteCount={_count?.likes} />
+        <RecipeInfoStats recipeId={id} isActive={isFavorite} isPublished={isPublished} favoriteCount={_count?.likes} />
       </div>
     </>
   );

--- a/src/app/my-recipe/[id]/_components/recipe-info-stats.tsx
+++ b/src/app/my-recipe/[id]/_components/recipe-info-stats.tsx
@@ -1,24 +1,24 @@
 "use client";
 
-import { experimental_useOptimistic as useOptimistic } from "react";
 import Link from "next/link";
 
-import { favoriteRecipe, unFavoriteRecipe } from "@/src/actions/favoriteRecipeActions";
+import { favoriteRecipe, unFavoriteRecipe } from "@/src/actions/actionsForFavoriteRecipe";
 import ToggleButton from "@/src/components/toggle-button";
-import { useToast } from "@/src/components/ui/use-toast";
 import { useOptimisticToggle } from "@/src/hooks/useOptimisticToggle";
+import { cn } from "@/src/lib/utils";
 
 import NumberUnit from "../../../../components/number-unit";
-import { Button, buttonVariants } from "../../../../components/ui/button";
+import { buttonVariants } from "../../../../components/ui/button";
 import { CONSTANTS } from "../../../../constants/constants";
 
 type Props = {
   recipeId: string;
   isActive: boolean;
+  isPublished: boolean;
   favoriteCount: number;
 };
 
-const RecipeInfoStats = ({ recipeId, isActive, favoriteCount }: Props) => {
+const RecipeInfoStats = ({ recipeId, isActive, isPublished, favoriteCount }: Props) => {
   const { optimisticState, updateCount } = useOptimisticToggle({
     count: favoriteCount,
     isActive,
@@ -29,10 +29,14 @@ const RecipeInfoStats = ({ recipeId, isActive, favoriteCount }: Props) => {
   return (
     <>
       <div className="flex items-center gap-4">
-        <Button variant={"outline"} className=" border-tomato9 px-2 text-tomato9">
-          {/* // TODO: 公開中かどうかのフラグを追加 */}
-          公開中
-        </Button>
+        <span
+          className={buttonVariants({
+            variant: "outline",
+            className: cn(isPublished ? "border-tomato9 text-tomato9" : "border-mauve9 text-mauve9"),
+          })}
+        >
+          {isPublished ? "公開中" : "非公開"}
+        </span>
         <NumberUnit numbers={optimisticState.count} unit={CONSTANTS.FAVORITE} />
       </div>
       <div className="flex gap-4">

--- a/src/app/my-recipe/create/page.tsx
+++ b/src/app/my-recipe/create/page.tsx
@@ -12,10 +12,7 @@ import CloseButton from "./_components/close-button";
 const page = async ({ searchParams }: { searchParams: { [key: string]: string | undefined } }) => {
   const user = await getAuthenticatedUser();
 
-  if (!user) {
-    // TODO: 未ログイン時のリダイレクト先を変更する
-    redirect("/mock/unauthorized");
-  }
+  if (!user) redirect("/login");
 
   let defaultValues: Partial<CreateRecipeFormValues> = {
     uid: user.id,

--- a/src/app/new-recipes/page.tsx
+++ b/src/app/new-recipes/page.tsx
@@ -1,4 +1,4 @@
-import { getNewRecipesFromFollowingChefs } from "@/src/actions/getNewRecipesFromFollowingChefs";
+import { getRecipesNewFromFollowedChefs } from "@/src/actions/getRecipesNewFromFollowedChefs";
 import TopBar from "@/src/components/layout/top-bar";
 import LoadMore from "@/src/components/load-more";
 import RecipeList from "@/src/components/recipe-list";
@@ -6,19 +6,19 @@ import RouterBackButton from "@/src/components/router-back-button";
 import { kInfiniteScrollCount } from "@/src/constants/constants";
 
 const page = async () => {
-  const initialRecipes = await getNewRecipesFromFollowingChefs();
+  const initialRecipes = await getRecipesNewFromFollowedChefs();
 
   const loadMoreRecipes = async (offset: number = 0) => {
     "use server";
 
-    const newRecipesFromFollowingChefs = await getNewRecipesFromFollowingChefs({
+    const newRecipesFromFollowingChefs = await getRecipesNewFromFollowedChefs({
       skip: offset + kInfiniteScrollCount,
     });
 
     const nextOffset = offset + newRecipesFromFollowingChefs.length;
 
     return [
-      newRecipesFromFollowingChefs.map((recipe) => <RecipeList key={recipe.id} recipes={[recipe]} />),
+      newRecipesFromFollowingChefs.map((recipe) => <RecipeList key={recipe.id} recipes={[recipe]} segment="recipe" />),
       nextOffset,
     ] as const;
   };
@@ -34,7 +34,7 @@ const page = async () => {
         }
       />
       <LoadMore initialOffset={0} loadMoreAction={loadMoreRecipes}>
-        <RecipeList recipes={initialRecipes} />
+        <RecipeList recipes={initialRecipes} segment="recipe" />
       </LoadMore>
     </>
   );

--- a/src/app/recipe/[id]/_components/recipe-hero.tsx
+++ b/src/app/recipe/[id]/_components/recipe-hero.tsx
@@ -20,7 +20,16 @@ type Props = {
 };
 
 const RecipeHero = async ({ id }: Props) => {
-  const { title, description, isMe, RecipeLink: recipeLinks, _count, isFavorite, user } = await getRecipeById(id);
+  const {
+    title,
+    description,
+    isMe,
+    RecipeLink: recipeLinks,
+    _count,
+    isFavorite,
+    user,
+    isPublished,
+  } = await getRecipeById(id);
 
   const sortedRecipeLinks = sortSiteLinks(recipeLinks.map((recipeLink) => recipeLink.linkUrl));
 
@@ -71,7 +80,7 @@ const RecipeHero = async ({ id }: Props) => {
                 </Popover>
               )}
 
-              {isMe && <PopoverMenu recipeId={id} />}
+              {isMe && <PopoverMenu recipeId={id} isPublished={isPublished} />}
             </div>
           </div>
           <p className="text-mauve12">{description}</p>

--- a/src/app/recipe/[id]/_components/recipe-info-stats.tsx
+++ b/src/app/recipe/[id]/_components/recipe-info-stats.tsx
@@ -1,11 +1,8 @@
 "use client";
 
-import { experimental_useOptimistic as useOptimistic } from "react";
-
-import { favoriteRecipe, unFavoriteRecipe } from "@/src/actions/favoriteRecipeActions";
+import { favoriteRecipe, unFavoriteRecipe } from "@/src/actions/actionsForFavoriteRecipe";
 import ProfileLink from "@/src/components/profile-link";
 import ToggleButton from "@/src/components/toggle-button";
-import { useToast } from "@/src/components/ui/use-toast";
 import { useOptimisticToggle } from "@/src/hooks/useOptimisticToggle";
 
 import NumberUnit from "../../../../components/number-unit";

--- a/src/app/search/recipes/page.tsx
+++ b/src/app/search/recipes/page.tsx
@@ -27,7 +27,10 @@ const page = async ({ searchParams }: { searchParams: { search?: string } }) => 
 
     const nextOffset = offset + searchedRecipes.length;
 
-    return [searchedRecipes.map((recipe) => <RecipeList key={recipe.id} recipes={[recipe]} />), nextOffset] as const;
+    return [
+      searchedRecipes.map((recipe) => <RecipeList key={recipe.id} recipes={[recipe]} segment="recipe" />),
+      nextOffset,
+    ] as const;
   };
 
   return (
@@ -40,7 +43,7 @@ const page = async ({ searchParams }: { searchParams: { search?: string } }) => 
           </p>
           {searchedRecipes.length > 0 ? (
             <LoadMore initialOffset={0} loadMoreAction={loadMoreSearchRecipes}>
-              <RecipeList recipes={searchedRecipes} />
+              <RecipeList recipes={searchedRecipes} segment="recipe" />
             </LoadMore>
           ) : (
             <NoDataDisplay text={"お探しのレシピが見つかりませんでした。"} />

--- a/src/components/no-data-display.tsx
+++ b/src/components/no-data-display.tsx
@@ -14,7 +14,7 @@ const NoDataDisplay = async ({ text }: Props) => {
         src="https://uploads-ssl.webflow.com/603c87adb15be3cb0b3ed9b5/61bf07d2cce98fb122df3dd3_1.png"
         alt="No result"
       />
-      <p className="font-bold text-mauve12">{text}</p>
+      <p className="px-4 text-center font-bold text-mauve12">{text}</p>
     </div>
   );
 };

--- a/src/components/recipe-card.tsx
+++ b/src/components/recipe-card.tsx
@@ -9,18 +9,23 @@ type Props = {
   title: string;
   description: string;
   favorites: number;
+  isPublished: boolean;
 };
 
-const RecipeCard = ({ path, imageUrl, title, description, favorites }: Props) => {
+const RecipeCard = ({ path, imageUrl, title, description, favorites, isPublished }: Props) => {
   return (
     <Link href={path} className="relative">
       <Image src={imageUrl} layout="responsive" className="w-full rounded-2xl" alt={title} width={160} height={160} />
       {favorites > 0 && (
         <div className="absolute right-2 top-2 rounded-2xl bg-[#040013]/[.48] p-2 leading-none text-mauve1">
-          <div className="flex items-center gap-2">
-            <Heart size={16} />
-            <span>{favorites}</span>
-          </div>
+          {isPublished ? (
+            <div className="flex items-center gap-2">
+              <Heart size={16} />
+              <span>{favorites}</span>
+            </div>
+          ) : (
+            <span>非公開</span>
+          )}
         </div>
       )}
       <p className="mt-2 line-clamp-2 font-bold text-mauve12">{title}</p>

--- a/src/components/recipe-card.tsx
+++ b/src/components/recipe-card.tsx
@@ -19,7 +19,7 @@ const RecipeCard = ({ path, imageUrl, title, description, favorites }: Props) =>
         <div className="absolute right-2 top-2 rounded-2xl bg-[#040013]/[.48] p-2 leading-none text-mauve1">
           <div className="flex items-center gap-2">
             <Heart size={16} />
-            <span className="">{favorites}</span>
+            <span>{favorites}</span>
           </div>
         </div>
       )}

--- a/src/components/recipe-list.tsx
+++ b/src/components/recipe-list.tsx
@@ -6,20 +6,23 @@ type Props = {
     _count: {
       likes: number;
     };
+    isPublished: boolean;
     description: string;
     title: string;
   }[];
+  segment: string;
 };
 
-const RecipeList = ({ recipes: myRecipes }: Props) => {
+const RecipeList = ({ recipes, segment }: Props) => {
   return (
     <>
-      {myRecipes.map(({ id, _count, description, title }) => (
+      {recipes.map(({ id, _count, description, title, isPublished }) => (
         <li key={id} className="flex flex-col">
           <RecipeCard
-            path={`/my-recipe/${id}`}
+            path={`/${segment}/${id}`}
             favorites={_count.likes}
             description={description}
+            isPublished={isPublished}
             imageUrl="https://images.unsplash.com/photo-1595295333158-4742f28fbd85?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=640&q=80"
             title={title}
           />

--- a/src/prisma/migrations/20230809014005_v15/migration.sql
+++ b/src/prisma/migrations/20230809014005_v15/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Recipe" ADD COLUMN     "is_published" BOOLEAN NOT NULL DEFAULT false;

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -46,6 +46,7 @@ model Recipe {
   Instruction  Instruction[]
   RecipeLink   RecipeLink[]
   Ingredient   Ingredient[]
+  isPublished  Boolean       @default(false) @map("is_published")
   createdAt    DateTime?     @default(now()) @map("created_at") @db.Timestamptz(3)
   updatedAt    DateTime?     @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(3)
 }

--- a/src/types/SupabaseTypes.ts
+++ b/src/types/SupabaseTypes.ts
@@ -430,6 +430,7 @@ export interface Database {
           created_at: string | null;
           description: string;
           id: string;
+          is_published: boolean;
           serving_count: number;
           title: string;
           updated_at: string | null;
@@ -439,6 +440,7 @@ export interface Database {
           created_at?: string | null;
           description: string;
           id: string;
+          is_published?: boolean;
           serving_count: number;
           title: string;
           updated_at?: string | null;
@@ -448,6 +450,7 @@ export interface Database {
           created_at?: string | null;
           description?: string;
           id?: string;
+          is_published?: boolean;
           serving_count?: number;
           title?: string;
           updated_at?: string | null;


### PR DESCRIPTION
## 関連する issue\*

Closes #133 
Closes #134 
Closes #135 


<!--
次のいずれかを書いてください。
#issue番号（マージ時にまだ issue を close してはいけない場合）
Closes #番号（マージ時に issue を自動的に close させる場合）
-->

## 作業内容\*

<!-- 変更箇所および内容 -->

### メイン実装

以下２点の修正を行いました

- 話題のレシピの取得 API が一般ユーザーのレシピも対象となっていたので、シェフのレシピに限定
- 検索APIにて、検索ワードがない場合は話題のレシピの一覧取得。検索ワードがあれば、シェフの全レシピから検索をかける


https://github.com/qin-team-recipe/12-recipe-app/assets/63396451/1d00389e-b49d-4f44-b5ea-f7933a477fa9

また、レシピの公開・非公開のフラグをRecipeモデルに追加し、マイレシピ作成時はデフォルトで非公開にして、公開・非公開を切り替えられるように対応しました。


https://github.com/qin-team-recipe/12-recipe-app/assets/63396451/51866e99-28c8-453a-a9de-32c902c48a4e




### そのほか発生した実装

apiのprefixを`actionsFor~`,`getRecipes~`,`getChefs~`など管理しやすいように対応しました。

<img width="288" alt="スクリーンショット 2023-08-09 18 58 39" src="https://github.com/qin-team-recipe/12-recipe-app/assets/63396451/29b9c3cc-0dd2-4048-aa70-3cc0e9db8fd2">

またsession情報の呼び出しでcookieを呼び出していますが、現行の呼び出し方だと`pnpm run build`コマンドでコケていたので、以下を参考にcookies の取得と使用の方法を定義し直しました

https://github.com/vercel/next.js/issues/49373#issuecomment-1662263802

## 残してある課題

## チェックリスト\*

### 実装者

- [ ] ターゲットブランチが適切に設定されている。
- [ ] 新規でのバグ・警告等が残っていない。
- [ ] 本 PR に関係のない差分を含んでいない。
- [ ] PR の Assignee の設定。

## その他

<!-- UIの変更などがあれば -->
