### PR TITLE
管理者ログインページの製造

### DIFF
--- a/src/actions/getUserRole.ts
+++ b/src/actions/getUserRole.ts
@@ -1,0 +1,13 @@
+"use server";
+
+import { prisma } from "@/src/lib/prisma";
+
+export const getUserRole = async (id: string | undefined) => {
+  const user = await prisma.user.findFirst({
+    where: {
+      id,
+    },
+  });
+
+  return user?.role;
+};

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,6 +1,3 @@
-import { redirect } from "next/navigation";
-
-import { getAuthenticatedUser } from "@/src/actions/getAuthenticatedUser";
 import { Separator } from "@/src/components/ui/separator";
 
 export const metadata = {
@@ -8,12 +5,6 @@ export const metadata = {
 };
 
 const layout = async ({ children }: { children: React.ReactNode }) => {
-  const user = await getAuthenticatedUser();
-
-  if (!user || user.role !== "ADMIN") {
-    redirect("/");
-  }
-
   return (
     <>
       <Separator className="hidden h-full w-[1px] md:block" />

--- a/src/app/admin/login/_components/index.ts
+++ b/src/app/admin/login/_components/index.ts
@@ -1,0 +1,3 @@
+export { default as AdminLoginForm } from "./login-form";
+export { loginFormSchema } from "./schema";
+export type { LoginFormValues } from "./schema";

--- a/src/app/admin/login/_components/login-form.tsx
+++ b/src/app/admin/login/_components/login-form.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useTransition } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+
+import { getUserRole } from "@/src/actions/getUserRole";
+import { Button } from "@/src/components/ui/button";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/src/components/ui/form";
+import { Input } from "@/src/components/ui/input";
+import Spinner from "@/src/components/ui/spinner";
+import { useToast } from "@/src/components/ui/use-toast";
+import { kToastDuration } from "@/src/constants/constants";
+import type { Database } from "@/src/types/SupabaseTypes";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { useForm } from "react-hook-form";
+
+import { loginFormSchema, LoginFormValues } from "./schema";
+
+type Props = {
+  defaultValues: LoginFormValues;
+};
+
+const AdminLoginForm = ({ defaultValues }: Props) => {
+  const router = useRouter();
+  const supabase = createClientComponentClient<Database>();
+  const { toast } = useToast();
+  const [isPending, startTransition] = useTransition();
+
+  const form = useForm({
+    defaultValues,
+    resolver: zodResolver(loginFormSchema),
+    mode: "onChange",
+  });
+
+  const login = form.handleSubmit((formValues) => {
+    startTransition(async () => {
+      try {
+        const { data, error } = await supabase.auth.signInWithPassword({
+          email: formValues.email,
+          password: formValues.password,
+        });
+
+        if (error) {
+          toast({
+            variant: "destructive",
+            title: error.message,
+            duration: kToastDuration,
+          });
+          return;
+        }
+
+        const role = await getUserRole(data.user.id);
+
+        if (role === undefined || role !== "ADMIN") {
+          toast({
+            variant: "destructive",
+            title: "管理者の権限を持つアカウントでログインしてください。",
+            duration: kToastDuration,
+          });
+          return;
+        }
+
+        router.push("/admin");
+      } catch (error) {
+        toast({
+          variant: "destructive",
+          title: "エラーが発生しました。",
+          duration: kToastDuration,
+        });
+        return;
+      } finally {
+        router.refresh();
+      }
+    });
+  });
+
+  return (
+    <>
+      <Form {...form}>
+        <form onSubmit={login} className="mb-8 grid gap-8">
+          <FormField
+            control={form.control}
+            name="email"
+            render={({ field }) => (
+              <FormItem className="grid space-y-0">
+                <FormLabel className="mb-1 ml-3 mt-5 text-lg font-bold">メールアドレス</FormLabel>
+                <FormControl>
+                  <Input className="w-full rounded-none border-x-0" {...field} />
+                </FormControl>
+                <FormMessage className="ml-3" />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="password"
+            render={({ field }) => (
+              <FormItem className="grid space-y-0">
+                <FormLabel className="mb-1 ml-3 mt-5 text-lg font-bold">パスワード</FormLabel>
+                <FormControl>
+                  <Input className="w-full rounded-none border-x-0" {...field} />
+                </FormControl>
+                <FormMessage className="ml-3" />
+              </FormItem>
+            )}
+          />
+          <Button variant="destructive" className="flex-1 gap-2" type="submit">
+            {isPending && <Spinner />} 管理者としてログインする
+          </Button>
+        </form>
+      </Form>
+      <div className="text-center text-sm">
+        <Link href="/" className="font-bold text-gray-500">
+          一流レシピにログインする
+        </Link>
+      </div>
+    </>
+  );
+};
+
+export default AdminLoginForm;

--- a/src/app/admin/login/_components/schema.ts
+++ b/src/app/admin/login/_components/schema.ts
@@ -1,0 +1,8 @@
+import * as z from "zod";
+
+export type LoginFormValues = z.infer<typeof loginFormSchema>;
+
+export const loginFormSchema = z.object({
+  email: z.string().email({ message: "メールアドレスの形式ではありません。" }),
+  password: z.string().min(6, { message: "6文字以上入力する必要があります。" }),
+});

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -1,0 +1,38 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+
+import { getUserRole } from "@/src/actions/getUserRole";
+import TopBar from "@/src/components/layout/top-bar";
+import type { Database } from "@/src/types/SupabaseTypes";
+import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
+
+import { AdminLoginForm, LoginFormValues } from "./_components";
+
+export const metadata = {
+  title: "管理者ログイン画面",
+};
+
+const AdminLoginPage = async () => {
+  const cookieStore = cookies();
+  const {
+    data: { session },
+  } = await createServerComponentClient<Database>({ cookies: () => cookieStore }).auth.getSession();
+
+  const role = await getUserRole(session?.user.id);
+
+  if (role !== undefined && role === "ADMIN") redirect("/admin");
+
+  const defaultValues: LoginFormValues = {
+    email: "",
+    password: "",
+  };
+
+  return (
+    <>
+      <TopBar centerComponent={<h1 className="font-bold text-mauve12 md:text-xl">管理者ログイン</h1>} />
+      <AdminLoginForm defaultValues={defaultValues} />
+    </>
+  );
+};
+
+export default AdminLoginPage;

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,8 +1,22 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+
 import { getChefs } from "@/src/actions/getChefs";
+import { getUserRole } from "@/src/actions/getUserRole";
+import type { Database } from "@/src/types/SupabaseTypes";
+import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
 
 import { ChefsDataTable } from "./_components/chefs-data-table";
 
 const page = async () => {
+  const cookieStore = cookies();
+  const {
+    data: { session },
+  } = await createServerComponentClient<Database>({ cookies: () => cookieStore }).auth.getSession();
+
+  const role = await getUserRole(session?.user.id);
+  if (role === undefined || role !== "ADMIN") redirect("/admin/login");
+
   const data = await getChefs();
 
   return (


### PR DESCRIPTION
## 関連する
Closes #143 

## 作業内容
管理者用ログインフォームの実装

## 残してある課題
* ユーザと管理者を同じテーブルで管理しているため、admin/loginページから管理者以外のユーザでログインができてしまう。
* 一応エラーメッセージを出すようにしているが問題がある。例えばadmin/loginページでChefユーザでログインするとエラーになる。そのあと /favorite等の認証が必要なページへ遷移するとそのままログインできてしまう。



## チェックリスト\*

### 実装者

- [ ] ターゲットブランチが適切に設定されている。
- [ ] 新規でのバグ・警告等が残っていない。
- [ ] 本 PR に関係のない差分を含んでいない。
- [ ] PR の Assignee の設定。

## その他

<!-- UIの変更などがあれば -->
